### PR TITLE
Tile the overlay via CALayer pattern — physical footprint 131 MB → 18 MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Or `make run` to try it from `dist/` without installing. Look for the paper-shee
 ## How it works
 
 - One borderless, transparent `NSWindow` per display at `.screenSaver` window level (above the menu bar), with `ignoresMouseEvents = true` so all input passes through.
-- The paper grain replicates SVG's `feTurbulence type="fractalNoise" baseFrequency="1.5" numOctaves="3"`: several octaves of seamlessly tileable value noise are summed, then mapped to translucent dark/light speckles. One 256×256 tile is generated per texture and pattern-tiled across the screen by Core Graphics.
+- The paper grain replicates SVG's `feTurbulence type="fractalNoise" baseFrequency="1.5" numOctaves="3"`: several octaves of seamlessly tileable value noise are summed, then mapped to translucent dark/light speckles. One 256×256 tile is generated per texture and tiled across the screen by the CoreAnimation render server, so memory stays flat no matter the resolution.
 - The intensity slider just drives the overlay window's `alphaValue` — the texture itself is rendered once and cached.
 
 ## Development

--- a/Sources/Deckle/OverlayWindow.swift
+++ b/Sources/Deckle/OverlayWindow.swift
@@ -39,23 +39,26 @@ final class OverlayWindow: NSWindow {
     }
 }
 
-/// Draws the tint wash plus the tiled grain pattern.
+/// Shows the texture as a CALayer pattern background instead of drawing it.
+/// A drawn view forces AppKit to allocate window-sized backing stores
+/// (~30 MB per buffer on a Retina display); a pattern background color is
+/// tiled by the CoreAnimation render server from the single 256×256 tile,
+/// so the overlay costs kilobytes of process memory regardless of screen size.
 final class TextureView: NSView {
     private var texture: TexturePreset?
-    private var tile: NSImage?
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        wantsLayer = true
+        layerContentsRedrawPolicy = .never
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
 
     func apply(texture: TexturePreset) {
         guard texture != self.texture else { return }
         self.texture = texture
-        self.tile = TextureRenderer.tile(for: texture)
-        needsDisplay = true
-    }
-
-    override func draw(_ dirtyRect: NSRect) {
-        guard let texture, let tile else { return }
-        texture.tint.withAlphaComponent(texture.tintAlpha).setFill()
-        bounds.fill(using: .sourceOver)
-        NSColor(patternImage: tile).setFill()
-        bounds.fill(using: .sourceOver)
+        let tile = TextureRenderer.compositeTile(for: texture)
+        layer?.backgroundColor = NSColor(patternImage: tile).cgColor
     }
 }

--- a/Sources/Deckle/TextureRenderer.swift
+++ b/Sources/Deckle/TextureRenderer.swift
@@ -9,6 +9,7 @@ import CoreGraphics
 enum TextureRenderer {
     /// Cached tiles keyed by preset id.
     private static var tileCache: [String: NSImage] = [:]
+    private static var compositeCache: [String: NSImage] = [:]
     private static var previewCache: [String: NSImage] = [:]
 
     /// A small seamless tile; Core Graphics pattern fill repeats it across the
@@ -62,6 +63,24 @@ enum TextureRenderer {
         }
 
         tileCache[preset.id] = image
+        return image
+    }
+
+    /// The overlay tile: grain composited over the preset's tint wash, so a
+    /// single pattern image carries the whole texture. Used as a CALayer
+    /// pattern background — see TextureView for why.
+    static func compositeTile(for preset: TexturePreset) -> NSImage {
+        if let cached = compositeCache[preset.id] { return cached }
+
+        let grain = tile(for: preset)
+        let size = grain.size
+        let image = NSImage(size: size, flipped: false) { rect in
+            preset.tint.withAlphaComponent(preset.tintAlpha).setFill()
+            rect.fill(using: .sourceOver)
+            grain.draw(in: rect, from: .zero, operation: .sourceOver, fraction: 1)
+            return true
+        }
+        compositeCache[preset.id] = image
         return image
     }
 

--- a/Support/Info.plist
+++ b/Support/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.3</string>
+	<string>1.3.4</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Activity Monitor showed Deckle at ~177-190 MB. `vmmap` traced almost all of it to **CoreAnimation: 115 MB dirty** — the overlay's drawn view forces AppKit to allocate window-sized Retina backing stores just to hold a repeated 256 px tile.

**Fix:** stop drawing. The content view's layer now uses a *pattern background color* built from a composite tile (tint wash + grain baked together, new `TextureRenderer.compositeTile`). The CoreAnimation render server tiles it GPU-side, so no full-screen buffer ever exists in-process.

**Measured (release build, single Retina display):**
| | before | after |
|---|---|---|
| CoreAnimation dirty | 115.2 MB | **0.5 MB** |
| Physical footprint | ~131 MB | **18.0 MB** |

Verified the pattern renders with correct alpha compositing (offscreen sample test) and the overlay window still shows at the right level/alpha. Bumps to 1.3.4 so it can ship immediately after merge.