### PR TITLE
Modernize menu UI and add live Paper Mill previews

### DIFF
--- a/Sources/Deckle/AppState.swift
+++ b/Sources/Deckle/AppState.swift
@@ -103,11 +103,23 @@ final class AppState: ObservableObject {
         }
     }
 
+    /// Draft paper the Paper Mill is previewing live on the real overlay
+    /// windows. Deliberately not persisted and not written to `defaults` —
+    /// it only ever lives as long as the editor window.
+    @Published var previewPaper: CustomPaper?
+
     var texture: TexturePreset {
         if let custom = customPapers.first(where: { $0.id == textureID }) {
             return TexturePreset(custom: custom)
         }
         return TexturePreset.preset(id: textureID)
+    }
+
+    /// What the overlay windows should render right now: a live Paper Mill
+    /// draft when one is being previewed, otherwise the selected texture.
+    var effectiveTexture: TexturePreset {
+        if let previewPaper { return TexturePreset(custom: previewPaper) }
+        return texture
     }
 
     var isSnoozed: Bool {

--- a/Sources/Deckle/CommunityBrowser.swift
+++ b/Sources/Deckle/CommunityBrowser.swift
@@ -27,15 +27,18 @@ final class CommunityBrowser: ObservableObject {
     private static let base = "https://raw.githubusercontent.com/YellowFoxH4XOR/deckle-papers/main"
 
     func open() {
+        MenuDismiss.dismiss()
         if window == nil {
             let hosting = NSHostingController(rootView: CommunityView(browser: self))
             let window = NSWindow(contentViewController: hosting)
             window.title = "Community Papers"
             window.styleMask = [.titled, .closable]
             window.isReleasedWhenClosed = false
+            window.level = .floating
             window.center()
             self.window = window
         }
+        window?.orderFrontRegardless()
         window?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
         if status == .idle { Task { await load() } }

--- a/Sources/Deckle/FeaturePromoCard.swift
+++ b/Sources/Deckle/FeaturePromoCard.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+import AppKit
+
+/// Rotating feature card for discoverable actions without nested controls.
+struct FeaturePromoCard: View {
+    var onOpenMill: (() -> Void)? = nil
+    @AppStorage("dismissedPaperMillTip") private var isDismissed = false
+    @State private var currentTipIndex = 0
+
+    private struct PromoTip {
+        let icon: String
+        let iconColor: Color
+        let iconBackground: Color
+        let title: String
+        let description: String
+        let action: () -> Void
+    }
+
+    private var tips: [PromoTip] {
+        [
+            PromoTip(
+                icon: "wand.and.stars",
+                iconColor: .purple,
+                iconBackground: Color.purple.opacity(0.12),
+                title: "Blend custom paper in Paper Mill",
+                description: "Mix custom washes, woven fibers, and organic blotches to make a tactile texture.",
+                action: {
+                    if let onOpenMill {
+                        onOpenMill()
+                    } else {
+                        PaperMill.shared.open()
+                    }
+                }
+            ),
+            PromoTip(
+                icon: "globe.americas.fill",
+                iconColor: .blue,
+                iconBackground: Color.blue.opacity(0.12),
+                title: "Explore community papers",
+                description: "Browse and install handcrafted paper textures from the open-source community.",
+                action: { CommunityBrowser.shared.open() }
+            )
+        ]
+    }
+
+    var body: some View {
+        if !isDismissed {
+            let tip = tips[currentTipIndex % tips.count]
+
+            HStack(alignment: .top, spacing: 8) {
+                Button(action: tip.action) {
+                    HStack(alignment: .top, spacing: 12) {
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(tip.iconBackground)
+                                .frame(width: 38, height: 38)
+
+                            Image(systemName: tip.icon)
+                                .font(.system(size: 17, weight: .semibold))
+                                .foregroundStyle(tip.iconColor)
+                        }
+
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(tip.title)
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundStyle(.primary)
+                                .lineLimit(1)
+
+                            Text(tip.description)
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+
+                        Spacer(minLength: 0)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .frame(maxWidth: .infinity)
+
+                VStack(spacing: 8) {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            isDismissed = true
+                        }
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundStyle(.tertiary)
+                            .padding(4)
+                            .background(Color.primary.opacity(0.04))
+                            .clipShape(Circle())
+                    }
+                    .buttonStyle(.plain)
+                    .help("Dismiss tip")
+
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            currentTipIndex = (currentTipIndex + 1) % tips.count
+                        }
+                    } label: {
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundStyle(.secondary)
+                            .padding(4)
+                            .background(Color.primary.opacity(0.04))
+                            .clipShape(Circle())
+                    }
+                    .buttonStyle(.plain)
+                    .help("Next tip")
+                }
+            }
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(Color(nsColor: .controlBackgroundColor).opacity(0.85))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14)
+                    .stroke(Color.primary.opacity(0.06), lineWidth: 1)
+            )
+        }
+    }
+}

--- a/Sources/Deckle/HeroCardView.swift
+++ b/Sources/Deckle/HeroCardView.swift
@@ -1,0 +1,268 @@
+import SwiftUI
+import AppKit
+
+/// Prominent hero card displaying current texture status, preview avatar,
+/// master toggle pill button, and quick intensity slider.
+struct HeroCardView: View {
+    @EnvironmentObject private var state: AppState
+    @Binding var isDetailsExpanded: Bool
+
+    private var displayCount: Int {
+        NSScreen.screens.count
+    }
+
+    private var activeDisplaysSummary: String {
+        let active = NSScreen.screens.compactMap { $0.displayID }.filter { !state.excludedDisplays.contains(String($0)) }
+        if active.count == displayCount {
+            return displayCount == 1 ? "1 DISPLAY" : "\(displayCount) DISPLAYS"
+        } else {
+            return "\(active.count)/\(displayCount) ACTIVE"
+        }
+    }
+
+    private var metaLine: String {
+        let statusString: String
+        if state.isSnoozed {
+            statusString = "SNOOZED"
+        } else if state.isEnabled {
+            statusString = "ACTIVE"
+        } else {
+            statusString = "PAUSED"
+        }
+        return "ENGINE V2 • \(activeDisplaysSummary) • \(statusString)"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            // Meta header row
+            HStack {
+                Text(metaLine)
+                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if state.isSnoozed, let until = state.snoozeUntil {
+                    HStack(spacing: 3) {
+                        Image(systemName: "timer")
+                            .font(.system(size: 10))
+                        Text(timerInterval: Date()...until, countsDown: true)
+                            .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    }
+                    .foregroundStyle(.orange)
+                }
+            }
+
+            // Main identity row
+            HStack(spacing: 14) {
+                // Circular texture swatch
+                ZStack {
+                    Circle()
+                        .fill(Color(nsColor: .controlBackgroundColor))
+                        .frame(width: 50, height: 50)
+                        .shadow(color: .black.opacity(0.08), radius: 3, x: 0, y: 1)
+
+                    Image(nsImage: TextureRenderer.preview(
+                        for: state.texture,
+                        size: CGSize(width: 50, height: 50)
+                    ))
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 48, height: 48)
+                    .clipShape(Circle())
+                    .overlay(
+                        Circle()
+                            .stroke(
+                                state.shouldShowOverlay ? Color.accentColor.opacity(0.6) : Color.primary.opacity(0.12),
+                                lineWidth: 1.5
+                            )
+                    )
+                }
+
+                // Texture name & status text
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(state.texture.name)
+                        .font(.system(size: 19, weight: .bold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(statusColor)
+                            .frame(width: 8, height: 8)
+                            .shadow(color: statusColor.opacity(0.5), radius: 3, x: 0, y: 0)
+
+                        Text(statusLabel)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(statusColor)
+                    }
+                }
+
+                Spacer()
+            }
+
+            // Primary action button & options button
+            HStack(spacing: 10) {
+                // Main toggle pill button
+                Button(action: toggleOverlay) {
+                    HStack(spacing: 8) {
+                        Image(systemName: mainButtonIcon)
+                            .font(.system(size: 13, weight: .semibold))
+                        Text(mainButtonTitle)
+                            .font(.system(size: 14, weight: .semibold))
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 38)
+                    .background(mainButtonBackground)
+                    .foregroundStyle(mainButtonForeground)
+                    .clipShape(Capsule())
+                    .overlay(
+                        Capsule()
+                            .stroke(mainButtonBorder, lineWidth: 1)
+                    )
+                    .shadow(color: .black.opacity(0.04), radius: 2, y: 1)
+                }
+                .buttonStyle(.plain)
+
+                // Secondary "..." options button
+                Button(action: {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                        isDetailsExpanded.toggle()
+                    }
+                }) {
+                    ZStack {
+                        Circle()
+                            .fill(Color(nsColor: .controlBackgroundColor))
+                            .frame(width: 38, height: 38)
+                            .shadow(color: .black.opacity(0.04), radius: 2, y: 1)
+
+                        Image(systemName: isDetailsExpanded ? "slider.horizontal.3" : "ellipsis")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(isDetailsExpanded ? Color.accentColor : Color.primary.opacity(0.75))
+                    }
+                    .overlay(
+                        Circle()
+                            .stroke(isDetailsExpanded ? Color.accentColor.opacity(0.5) : Color.primary.opacity(0.12), lineWidth: 1)
+                    )
+                }
+                .buttonStyle(.plain)
+                .help(isDetailsExpanded ? "Hide adjustments" : "Adjust grain & fine-tuning")
+            }
+
+            // Inline Intensity Slider
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Label {
+                        Text("Intensity")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.secondary)
+                    } icon: {
+                        Image(systemName: "sun.min")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+
+                    Text("\(Int(state.intensity * 100))%")
+                        .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(.primary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.primary.opacity(0.06))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+
+                Slider(value: $state.intensity, in: 0.05...0.45)
+                    .tint(.accentColor)
+                    .disabled(!state.isEnabled)
+            }
+            .padding(.top, 2)
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 18)
+                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.92))
+                .shadow(color: .black.opacity(0.06), radius: 8, x: 0, y: 3)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
+    }
+
+    // MARK: - Helper properties & actions
+
+    private var statusColor: Color {
+        if state.isSnoozed {
+            return .orange
+        } else if state.isEnabled {
+            return Color(nsColor: .systemGreen)
+        } else {
+            return .secondary
+        }
+    }
+
+    private var statusLabel: String {
+        if state.isSnoozed {
+            return "Snoozed"
+        } else if state.isEnabled {
+            return "Active"
+        } else {
+            return "Paused"
+        }
+    }
+
+    private var mainButtonTitle: String {
+        if state.isSnoozed {
+            return "Resume texture"
+        } else if state.isEnabled {
+            return "Pause texture"
+        } else {
+            return "Enable texture"
+        }
+    }
+
+    private var mainButtonIcon: String {
+        if state.isSnoozed {
+            return "play.fill"
+        } else if state.isEnabled {
+            return "pause.fill"
+        } else {
+            return "power"
+        }
+    }
+
+    private var mainButtonBackground: Color {
+        if state.isSnoozed || !state.isEnabled {
+            return Color.accentColor
+        } else {
+            return Color(nsColor: .windowBackgroundColor)
+        }
+    }
+
+    private var mainButtonForeground: Color {
+        if state.isSnoozed || !state.isEnabled {
+            return .white
+        } else {
+            return .primary
+        }
+    }
+
+    private var mainButtonBorder: Color {
+        if state.isSnoozed || !state.isEnabled {
+            return Color.accentColor.opacity(0.8)
+        } else {
+            return Color.primary.opacity(0.12)
+        }
+    }
+
+    private func toggleOverlay() {
+        if state.isSnoozed {
+            state.cancelSnooze()
+            state.isEnabled = true
+        } else if state.isEnabled {
+            state.isEnabled = false
+        } else {
+            state.isEnabled = true
+        }
+    }
+}

--- a/Sources/Deckle/MenuDismiss.swift
+++ b/Sources/Deckle/MenuDismiss.swift
@@ -1,0 +1,16 @@
+import AppKit
+
+/// Dismisses an open MenuBarExtra content window before presenting a
+/// standalone window. It deliberately ignores generic panels and status-bar
+/// windows so colour pickers and the app's menu-bar entry stay untouched.
+enum MenuDismiss {
+    @MainActor
+    static func dismiss() {
+        for window in NSApp.windows {
+            let className = String(describing: type(of: window))
+            if className.contains("MenuBarExtra") || className.contains("Popover") {
+                window.orderOut(nil)
+            }
+        }
+    }
+}

--- a/Sources/Deckle/MenuView.swift
+++ b/Sources/Deckle/MenuView.swift
@@ -1,441 +1,457 @@
 import SwiftUI
-import ServiceManagement
+import AppKit
 
-/// Content of the menu bar popover: master toggle, intensity slider,
-/// sectioned texture picker, snooze controls, per-display toggles, footer.
+/// Modern, elevated menu bar popover for Deckle.
+/// Features direct Paper Mill opening, search field, prominent hero status card,
+/// feature spotlight card, preset carousel/grid with scroll affordances, and expandable fine-tuning drawer.
 struct MenuView: View {
     @EnvironmentObject private var state: AppState
     @ObservedObject private var updater = UpdateManager.shared
-    @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
-
-    private var isBundled: Bool {
-        Bundle.main.bundleURL.pathExtension == "app"
-    }
+    @State private var searchText = ""
+    @ObservedObject private var mill = PaperMill.shared
+    @State private var isDetailsExpanded = false
+    @State private var showNotificationSheet = false
+    @State private var dismissedUpdateVersion: String?
+    @FocusState private var isSearchFocused: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            header
-            intensitySection
-            Divider()
-            textureSections
-            Divider()
-            grainSection
-            Divider()
-            snoozeSection
-            if NSScreen.screens.count > 1 {
-                Divider()
-                displaysSection
+        VStack(spacing: 12) {
+            // 1. Top Navigation & Action Header (Always Pinned at Top)
+            topHeaderBar
+
+            // 2. Search Bar
+            searchBar
+
+            // 3. Update & Notification Banner
+            if case .available(let version) = updater.status, dismissedUpdateVersion != version {
+                updateBanner(version: version)
+                    .transition(.asymmetric(
+                        insertion: .move(edge: .top).combined(with: .opacity),
+                        removal: .scale.combined(with: .opacity)
+                    ))
+            } else if updater.status == .installing {
+                installingBanner
+            } else if showNotificationSheet {
+                notificationBanner
+                    .transition(.asymmetric(
+                        insertion: .move(edge: .top).combined(with: .opacity),
+                        removal: .opacity
+                    ))
             }
-            Divider()
-            appRulesSection
-            Divider()
+
+            if !isSearching {
+                HeroCardView(isDetailsExpanded: $isDetailsExpanded)
+            }
+
+            // The header control must stay functional while search results are shown.
+            if isDetailsExpanded {
+                QuickControlsView(isExpanded: $isDetailsExpanded)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+
+            if !isSearching && !isDetailsExpanded {
+                FeaturePromoCard {
+                    PaperMill.shared.open()
+                }
+            }
+
+            // 7. Preset Carousel / Grid
+            PresetCollectionView(
+                searchText: $searchText,
+                onOpenMill: { paper, isNew in
+                    if isNew {
+                        PaperMill.shared.compose(from: paper)
+                    } else {
+                        PaperMill.shared.open(editing: paper)
+                    }
+                }
+            )
+
+            // 8. Footer Info & Actions
             footer
         }
         .padding(14)
-        .frame(width: 336)
+        .frame(width: 370)
+        .background(Color(nsColor: .windowBackgroundColor).opacity(0.96))
+        .animation(.spring(response: 0.32, dampingFraction: 0.82), value: isDetailsExpanded)
+        .animation(.easeInOut(duration: 0.2), value: isSearching)
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: showNotificationSheet)
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: dismissedUpdateVersion)
     }
 
-    private var statusText: String {
-        if state.isSnoozed { return "Snoozed" }
-        if !state.isEnabled { return "Off" }
-        return "\(state.texture.name) · \(Int(state.intensity * 100))%"
-    }
+    // MARK: - 1. Top Header Bar (Matching Reference Design)
 
-    private var header: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 1) {
-                Text("Deckle")
-                    .font(.headline)
-                Text(statusText)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+    private var topHeaderBar: some View {
+        HStack(spacing: 8) {
+            // Capsule "Open Mill" / "Close Mill" button -> Toggles Paper Mill window
+            Button(action: {
+                PaperMill.shared.toggle()
+            }) {
+                HStack(spacing: 6) {
+                    ZStack {
+                        Circle()
+                            .fill(mill.isOpen ? Color.accentColor : Color.blue)
+                            .frame(width: 22, height: 22)
+
+                        Image(systemName: mill.isOpen ? "xmark" : "wand.and.stars")
+                            .font(.system(size: 11, weight: .bold))
+                            .foregroundStyle(Color.white)
+                    }
+
+                    Text(mill.isOpen ? "Close Mill" : "Open Mill")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.primary)
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(mill.isOpen ? Color.accentColor.opacity(0.1) : Color(nsColor: .controlBackgroundColor))
+                .clipShape(Capsule())
+                .overlay(
+                    Capsule()
+                        .stroke(mill.isOpen ? Color.accentColor.opacity(0.5) : Color.primary.opacity(0.12), lineWidth: 1)
+                )
+                .shadow(color: .black.opacity(0.04), radius: 2, y: 1)
             }
+            .buttonStyle(.plain)
+            .help(mill.isOpen ? "Close Paper Mill" : "Open Paper Mill to craft custom paper textures")
             Spacer()
-            Toggle("", isOn: $state.isEnabled)
-                .toggleStyle(.switch)
-                .labelsHidden()
-                .help("Toggle from anywhere with ⌥⌘P")
-        }
-    }
 
-    private var intensitySection: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                Text("Intensity")
-                    .font(.subheadline)
-                Spacer()
-                Text("\(Int(state.intensity * 100))%")
-                    .font(.caption)
-                    .monospacedDigit()
-                    .foregroundStyle(.secondary)
-            }
-            Slider(value: $state.intensity, in: 0.05...0.45)
-        }
-        .disabled(!state.isEnabled)
-    }
-
-    private var textureSections: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 10) {
-                textureGroup(title: "Papers", presets: TexturePreset.light)
-                textureGroup(title: "Dark", presets: TexturePreset.dark)
-                myPapersGroup
-            }
-            .padding(.vertical, 2)
-        }
-        .frame(height: 264)
-    }
-
-    private var myPapersGroup: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Text("My Papers")
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.secondary)
-                Spacer()
-                Button("New…") { PaperMill.shared.open() }
-                    .controlSize(.mini)
-                Button("Import…") { PaperFiles.importPapers() }
-                    .controlSize(.mini)
-                Button("Community…") { CommunityBrowser.shared.open() }
-                    .controlSize(.mini)
-            }
-            if !state.customPapers.isEmpty {
-                LazyVGrid(
-                    columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 3),
-                    spacing: 8
-                ) {
-                    ForEach(state.customPapers) { paper in
-                        TextureSwatch(
-                            preset: TexturePreset(custom: paper),
-                            isSelected: paper.id == state.textureID
-                        ) {
-                            state.textureID = paper.id
-                        }
-                        .contextMenu {
-                            Button("Edit…") { PaperMill.shared.open(editing: paper) }
-                            Button("Export…") { PaperFiles.export(paper) }
-                            Divider()
-                            Button("Delete", role: .destructive) {
-                                state.customPapers.removeAll { $0.id == paper.id }
-                            }
-                        }
-                    }
+            // 1. Prominent Notification / Update Bell Button (Matching Reference)
+            Button(action: {
+                let opening = !showNotificationSheet
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    if opening { dismissedUpdateVersion = nil }
+                    showNotificationSheet = opening
                 }
-            } else {
-                Text("Blend your own paper in the Mill — tint, wash, weave, blotch.")
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-            }
-        }
-    }
-
-    private func textureGroup(title: String, presets: [TexturePreset]) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text(title)
-                .font(.caption)
-                .fontWeight(.semibold)
-                .foregroundStyle(.secondary)
-            LazyVGrid(
-                columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 3),
-                spacing: 8
-            ) {
-                ForEach(presets) { preset in
-                    TextureSwatch(
-                        preset: preset,
-                        isSelected: preset.id == state.textureID
-                    ) {
-                        state.textureID = preset.id
-                    }
-                }
-            }
-        }
-    }
-
-    private var grainSection: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            HStack {
-                Text("Grain")
-                    .font(.subheadline)
-                Spacer()
-                Picker("", selection: $state.grainScale) {
-                    Text("Fine").tag(0.5)
-                    Text("Normal").tag(1.0)
-                    Text("Coarse").tag(2.0)
-                    Text("Grainy").tag(4.0)
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                .frame(width: 210)
-            }
-            HStack {
-                Text("Strength")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Slider(value: $state.grainStrength, in: 0.25...2.0)
-                Text("\(Int(state.grainStrength * 100))%")
-                    .font(.caption)
-                    .monospacedDigit()
-                    .foregroundStyle(.secondary)
-                    .frame(width: 38, alignment: .trailing)
-            }
-        }
-        .disabled(!state.isEnabled)
-    }
-
-    private var snoozeSection: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            if state.isSnoozed, let until = state.snoozeUntil {
-                HStack {
-                    Text("Snoozed for ")
-                        .font(.subheadline)
-                    + Text(timerInterval: Date()...until, countsDown: true)
-                        .font(.subheadline)
-                        .monospacedDigit()
-                    Spacer()
-                    Button("Resume") { state.cancelSnooze() }
-                        .controlSize(.small)
-                }
-            } else {
-                HStack {
-                    Text("Snooze")
-                        .font(.subheadline)
-                    Spacer()
-                    ForEach([15, 30, 60], id: \.self) { minutes in
-                        Button(minutes == 60 ? "1 h" : "\(minutes) m") {
-                            state.snooze(minutes: minutes)
-                        }
-                        .controlSize(.small)
-                    }
-                }
-                .disabled(!state.isEnabled)
-            }
-        }
-    }
-
-    private var displaysSection: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Displays")
-                .font(.subheadline)
-            ForEach(NSScreen.screens, id: \.self) { screen in
-                if let displayID = screen.displayID {
-                    Toggle(screen.localizedName, isOn: displayBinding(String(displayID)))
-                        .toggleStyle(.checkbox)
-                        .font(.caption)
-                }
-            }
-        }
-    }
-
-    private func displayBinding(_ id: String) -> Binding<Bool> {
-        Binding(
-            get: { !state.excludedDisplays.contains(id) },
-            set: { include in
-                if include {
-                    state.excludedDisplays.remove(id)
-                } else {
-                    state.excludedDisplays.insert(id)
-                }
-            }
-        )
-    }
-
-    @State private var appRulesExpanded = false
-
-    private var appRulesSection: some View {
-        DisclosureGroup(isExpanded: $appRulesExpanded) {
-            VStack(alignment: .leading, spacing: 6) {
-                Picker("", selection: $state.appRuleMode) {
-                    Text("Everywhere").tag(AppState.AppRuleMode.everywhere)
-                    Text("Except…").tag(AppState.AppRuleMode.except)
-                    Text("Only…").tag(AppState.AppRuleMode.only)
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-
-                if state.appRuleMode != .everywhere {
-                    ForEach(state.ruleApps) { app in
-                        HStack {
-                            Text(app.name)
-                                .font(.caption)
-                            Spacer()
-                            Button {
-                                state.ruleApps.removeAll { $0.bundleID == app.bundleID }
-                            } label: {
-                                Image(systemName: "xmark.circle.fill")
-                                    .foregroundStyle(.tertiary)
-                            }
-                            .buttonStyle(.plain)
-                        }
-                    }
-                    Button("Add App…") { addRuleApp() }
-                        .controlSize(.small)
-                    Text(state.appRuleMode == .except
-                         ? "Paper hides while these apps are active"
-                         : "Paper shows only while these apps are active")
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                }
-            }
-            .padding(.top, 6)
-        } label: {
-            HStack(spacing: 6) {
-                Text("App rules")
-                    .font(.subheadline)
-                if state.appRuleMode != .everywhere {
-                    Text(state.appRuleMode == .except ? "except \(state.ruleApps.count)" : "only \(state.ruleApps.count)")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                }
-            }
-        }
-        .disabled(!state.isEnabled)
-    }
-
-    private func addRuleApp() {
-        let panel = NSOpenPanel()
-        panel.directoryURL = URL(fileURLWithPath: "/Applications")
-        panel.allowedContentTypes = [.applicationBundle]
-        panel.allowsMultipleSelection = true
-        panel.message = "Choose apps for the rule list"
-        guard panel.runModal() == .OK else { return }
-        for url in panel.urls {
-            guard let bundle = Bundle(url: url), let id = bundle.bundleIdentifier else { continue }
-            let name = (bundle.infoDictionary?["CFBundleDisplayName"] as? String)
-                ?? (bundle.infoDictionary?["CFBundleName"] as? String)
-                ?? url.deletingPathExtension().lastPathComponent
-            if !state.ruleApps.contains(where: { $0.bundleID == id }) {
-                state.ruleApps.append(.init(bundleID: id, name: name))
-            }
-        }
-    }
-
-    private var footer: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            updateRow
-            Toggle("Hide texture in screenshots & recordings", isOn: $state.hideFromCapture)
-                .toggleStyle(.checkbox)
-                .font(.caption)
-            HStack {
-                Toggle("Launch at login", isOn: launchAtLoginBinding)
-                    .toggleStyle(.checkbox)
-                    .font(.caption)
-                    .disabled(!isBundled)
-                    .help(isBundled ? "" : "Available when running the bundled app")
-                Spacer()
-                Button("Quit") { NSApp.terminate(nil) }
-                    .controlSize(.small)
-                    .keyboardShortcut("q")
-            }
-            HStack {
-                Toggle("Install updates automatically", isOn: $updater.autoInstall)
-                    .toggleStyle(.checkbox)
-                    .font(.caption)
-                Spacer()
-                Button("Check now") {
+                if opening, updater.status != .checking, updater.status != .installing {
                     Task { await updater.check(userInitiated: true) }
                 }
-                .controlSize(.small)
-                .disabled(updater.status == .checking || updater.status == .installing)
-            }
-            HStack {
-                Text("v\(updater.currentVersion) · ⌥⌘P toggles the texture from anywhere")
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-                Spacer()
-                Link("★ GitHub", destination: URL(string: "https://github.com/YellowFoxH4XOR/deckle")!)
-                    .font(.caption2)
-            }
-        }
-    }
+            }) {
+                ZStack(alignment: .topTrailing) {
+                    ZStack {
+                        Circle()
+                            .fill(Color(nsColor: .controlBackgroundColor))
+                            .frame(width: 36, height: 36)
+                            .shadow(color: .black.opacity(0.05), radius: 2, y: 1)
 
-    @ViewBuilder
-    private var updateRow: some View {
-        switch updater.status {
-        case .available(let version):
-            HStack {
-                Text("Deckle \(version) is available")
-                    .font(.caption)
-                Spacer()
-                Button("Update") { updater.installLatest() }
-                    .controlSize(.small)
-                    .buttonStyle(.borderedProminent)
-            }
-        case .installing:
-            HStack(spacing: 6) {
-                ProgressView().controlSize(.small)
-                Text("Installing update — Deckle will relaunch…")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-        case .checking:
-            Text("Checking for updates…")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        case .upToDate:
-            Text("You're on the latest version")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        case .failed(let message):
-            Text(message)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        case .idle:
-            EmptyView()
-        }
-    }
-
-    private var launchAtLoginBinding: Binding<Bool> {
-        Binding(
-            get: { launchAtLogin },
-            set: { enable in
-                do {
-                    if enable {
-                        try SMAppService.mainApp.register()
-                    } else {
-                        try SMAppService.mainApp.unregister()
+                        Image(systemName: showNotificationSheet || isUpdateAvailable ? "bell.fill" : "bell")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(isUpdateAvailable ? Color.accentColor : Color.primary)
                     }
-                    launchAtLogin = enable
-                } catch {
-                    launchAtLogin = SMAppService.mainApp.status == .enabled
+                    .overlay(
+                        Circle()
+                            .stroke(
+                                isUpdateAvailable ? Color.accentColor.opacity(0.5) : Color.primary.opacity(0.12),
+                                lineWidth: 1
+                            )
+                    )
+
+                    // Active notification / update badge dot
+                    if isUpdateAvailable {
+                        Circle()
+                            .fill(Color.red)
+                            .frame(width: 9, height: 9)
+                            .overlay(Circle().stroke(Color(nsColor: .windowBackgroundColor), lineWidth: 1.5))
+                            .offset(x: 1, y: -1)
+                    }
                 }
             }
-        )
-    }
-}
+            .buttonStyle(.plain)
+            .help(isUpdateAvailable ? "Update Available" : "Notifications & Updates")
 
-/// One tappable texture thumbnail in the picker grid.
-private struct TextureSwatch: View {
-    let preset: TexturePreset
-    let isSelected: Bool
-    let action: () -> Void
+            // 2. Profile / Settings Button (Matching Reference)
+            Button(action: {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    isDetailsExpanded.toggle()
+                }
+            }) {
+                ZStack {
+                    Circle()
+                        .fill(Color(nsColor: .controlBackgroundColor))
+                        .frame(width: 36, height: 36)
+                        .shadow(color: .black.opacity(0.05), radius: 2, y: 1)
 
-    var body: some View {
-        Button(action: action) {
-            VStack(spacing: 4) {
-                Image(nsImage: TextureRenderer.preview(
-                    for: preset,
-                    size: CGSize(width: 88, height: 44)
-                ))
-                .resizable()
-                .aspectRatio(2, contentMode: .fit)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
+                    Image(systemName: "person.crop.circle")
+                        .font(.system(size: 17, weight: .regular))
+                        .foregroundStyle(isDetailsExpanded ? Color.accentColor : Color.primary)
+                }
                 .overlay(
-                    RoundedRectangle(cornerRadius: 6)
-                        .stroke(
-                            isSelected ? Color.accentColor : Color.primary.opacity(0.15),
-                            lineWidth: isSelected ? 2 : 1
-                        )
+                    Circle()
+                        .stroke(isDetailsExpanded ? Color.accentColor.opacity(0.5) : Color.primary.opacity(0.12), lineWidth: 1)
                 )
-                Text(preset.name)
-                    .font(.caption2)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
-                    .foregroundStyle(isSelected ? .primary : .secondary)
+            }
+            .buttonStyle(.plain)
+            .help(isDetailsExpanded ? "Hide adjustments" : "Profile & Adjustments")
+        }
+    }
+
+    private var isUpdateAvailable: Bool {
+        if case .available = updater.status { return true }
+        return false
+    }
+
+    private var isSearching: Bool {
+        !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    // MARK: - 2. Search Bar
+
+    private var searchBar: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(isSearchFocused ? Color.accentColor : .secondary)
+
+            TextField("Search all papers & textures…", text: $searchText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .focused($isSearchFocused)
+                .onChange(of: isSearchFocused) { focused in
+                    if focused {
+                        NSApp.activate(ignoringOtherApps: true)
+                    }
+                }
+
+            if !searchText.isEmpty {
+                Button(action: {
+                    searchText = ""
+                    isSearchFocused = false
+                }) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .help("Clear search")
             }
         }
-        .buttonStyle(.plain)
-        .help(preset.subtitle)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.9))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(isSearchFocused ? Color.accentColor.opacity(0.5) : Color.primary.opacity(0.08), lineWidth: 1)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            NSApp.activate(ignoringOtherApps: true)
+            isSearchFocused = true
+        }
+    }
+
+    // MARK: - 3. Update & Notification Banners
+
+    private func updateBanner(version: String) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color.accentColor.opacity(0.15))
+                    .frame(width: 36, height: 36)
+
+                Image(systemName: "sparkles")
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundStyle(Color.accentColor)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Deckle \(version) is available")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(.primary)
+
+                Text("New engine improvements ready.")
+                    .font(.system(size: 11, weight: .regular))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 4)
+
+            Button(action: {
+                updater.installLatest()
+            }) {
+                Text("Update")
+                    .font(.system(size: 12, weight: .semibold))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 5)
+                    .background(Color.accentColor)
+                    .foregroundStyle(.white)
+                    .clipShape(Capsule())
+                    .shadow(color: Color.accentColor.opacity(0.3), radius: 3, y: 1)
+            }
+            .buttonStyle(.plain)
+
+            Button(action: {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    dismissedUpdateVersion = version
+                }
+            }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.tertiary)
+                    .padding(5)
+                    .background(Color.primary.opacity(0.05))
+                    .clipShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .help("Dismiss notification")
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(Color(nsColor: .controlBackgroundColor))
+                .shadow(color: Color.accentColor.opacity(0.08), radius: 6, y: 2)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(Color.accentColor.opacity(0.25), lineWidth: 1)
+        )
+    }
+
+    private var installingBanner: some View {
+        HStack(spacing: 12) {
+            ProgressView()
+                .controlSize(.small)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Installing update…")
+                    .font(.system(size: 12, weight: .semibold))
+                Text("Deckle will relaunch automatically.")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
+    }
+
+    private var notificationBanner: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(notificationColor.opacity(0.12))
+                    .frame(width: 34, height: 34)
+
+                Image(systemName: notificationSymbol)
+                    .font(.system(size: 16))
+                    .foregroundStyle(notificationColor)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(updaterStatusText)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.primary)
+
+                Text("Version \(updater.currentVersion) · Spectral Engine v2")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button(action: {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    showNotificationSheet = false
+                }
+            }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(.tertiary)
+                    .padding(5)
+                    .background(Color.primary.opacity(0.04))
+                    .clipShape(Circle())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
+    }
+
+    private var updaterStatusText: String {
+        switch updater.status {
+        case .checking: return "Checking for updates…"
+        case .upToDate: return "Deckle is up to date"
+        case .available(let v): return "Version \(v) available"
+        case .installing: return "Installing update…"
+        case .failed(let err): return err
+        case .idle: return "No new notifications"
+        }
+    }
+
+    private var notificationSymbol: String {
+        switch updater.status {
+        case .checking: return "arrow.triangle.2.circlepath"
+        case .upToDate: return "checkmark.circle.fill"
+        case .available: return "arrow.down.circle.fill"
+        case .installing: return "arrow.down.circle.fill"
+        case .failed: return "exclamationmark.triangle.fill"
+        case .idle: return "bell.slash"
+        }
+    }
+
+    private var notificationColor: Color {
+        switch updater.status {
+        case .failed: return .orange
+        case .upToDate: return .green
+        case .available, .checking, .installing: return .accentColor
+        case .idle: return .secondary
+        }
+    }
+
+    // MARK: - 8. Footer
+
+    private var footer: some View {
+        HStack {
+            HStack(spacing: 4) {
+                Text("⌥⌘P")
+                    .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 2)
+                    .background(Color.primary.opacity(0.06))
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+
+                Text("toggles anywhere")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+            }
+
+            Spacer()
+
+            HStack(spacing: 8) {
+                Link("★ GitHub", destination: URL(string: "https://github.com/YellowFoxH4XOR/deckle")!)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(.secondary)
+
+                Text("·")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+
+                Button("Quit") {
+                    NSApp.terminate(nil)
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+                .keyboardShortcut("q")
+            }
+        }
+        .padding(.top, 2)
     }
 }

--- a/Sources/Deckle/OverlayController.swift
+++ b/Sources/Deckle/OverlayController.swift
@@ -66,9 +66,15 @@ final class OverlayController {
             seen.insert(displayID)
 
             let excluded = state.excludedDisplays.contains(String(displayID))
-            let visible = state.shouldShowOverlay
-                && !excluded
-                && state.appRuleAllows(frontmost: frontmostBundleID)
+            // A Paper Mill preview overrides both the on/off state and app rules —
+            // you have to be able to judge a draft while the overlay is off — but
+            // still honours per-display exclusions, so the preview lands exactly
+            // where the finished paper would.
+            let visible = !excluded && (
+                state.previewPaper != nil
+                    || (state.shouldShowOverlay
+                        && state.appRuleAllows(frontmost: frontmostBundleID))
+            )
 
             // .none removes the overlay from screenshots/recordings while it
             // stays visible on the physical display. Changing sharingType on
@@ -89,7 +95,7 @@ final class OverlayController {
             }()
 
             window.setFrame(screen.frame, display: true)
-            window.apply(texture: state.texture, adjustments: state.grainAdjustments)
+            window.apply(texture: state.effectiveTexture, adjustments: state.grainAdjustments)
 
             if visible {
                 if window.isVisible {

--- a/Sources/Deckle/PaperComfort.swift
+++ b/Sources/Deckle/PaperComfort.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+/// Evaluates eye-comfort metrics for a custom paper texture composited
+/// over screen content at a given overlay intensity.
+///
+/// Models the overlay compositing pipeline: `veil = intensity × wash`, with screen
+/// colour `c` transformed to `c' = c·(1 − veil) + tint·veil`.
+struct PaperComfort: Equatable {
+    /// Net veil opacity reaching the screen (intensity × wash), 0…1.
+    let veil: Double
+    /// Fraction of a pure-white screen's relative luminance removed by the veil.
+    let dimming: Double
+    /// WCAG 2.1 contrast ratio between white and black content seen through the paper.
+    let contrastRatio: Double
+    /// Fraction of a white screen's blue-channel light removed by the tint wash.
+    let blueReduction: Double
+    /// Correlated Colour Temperature of the tint wash in Kelvin (McCamy approximation).
+    let temperature: Double
+    /// Combined structural prominence of weave and blotch patterns, 0…1.
+    let patternLoad: Double
+
+    enum Grade: String, Equatable {
+        case excellent = "Excellent retention"
+        case good = "Good retention"
+        case reduced = "Reduced contrast"
+        case poor = "Heavy contrast loss"
+    }
+
+    var grade: Grade
+
+    var needsContrastWarning: Bool {
+        grade == .reduced || grade == .poor
+    }
+
+    static func evaluate(paper: CustomPaper, intensity: Double) -> PaperComfort {
+        func clamp(_ v: Double, _ range: ClosedRange<Double>) -> Double {
+            min(max(v, range.lowerBound), range.upperBound)
+        }
+
+        let r = clamp(paper.tintRed, 0...1)
+        let g = clamp(paper.tintGreen, 0...1)
+        let b = clamp(paper.tintBlue, 0...1)
+        let wash = clamp(paper.wash, 0.10...0.60)
+        let weave = clamp(paper.weave, 0...0.35)
+        let blotch = clamp(paper.blotch, 0...0.40)
+        let clampedIntensity = clamp(intensity, 0.05...0.45)
+
+        let veil = clampedIntensity * wash
+
+        // Composite white (1, 1, 1) and black (0, 0, 0) through the tint wash
+        let whiteCompR = (1.0 - veil) + r * veil
+        let whiteCompG = (1.0 - veil) + g * veil
+        let whiteCompB = (1.0 - veil) + b * veil
+
+        let blackCompR = r * veil
+        let blackCompG = g * veil
+        let blackCompB = b * veil
+
+        // WCAG 2.1 sRGB linearisation and relative luminance: L = 0.2126·R + 0.7152·G + 0.0722·B
+        func linearise(_ c: Double) -> Double {
+            c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4)
+        }
+
+        func luminance(r: Double, g: Double, b: Double) -> Double {
+            0.2126 * linearise(r) + 0.7152 * linearise(g) + 0.0722 * linearise(b)
+        }
+
+        let lWhite = luminance(r: whiteCompR, g: whiteCompG, b: whiteCompB)
+        let lBlack = luminance(r: blackCompR, g: blackCompG, b: blackCompB)
+
+        let dimming = max(0, min(1, 1.0 - lWhite))
+        let contrastRatio = (lWhite + 0.05) / (lBlack + 0.05)
+        let blueReduction = max(0, min(1, 1.0 - linearise((1.0 - veil) + b * veil)))
+
+        // Correlated Colour Temperature (CCT) via McCamy's formula
+        let linR = linearise(r)
+        let linG = linearise(g)
+        let linB = linearise(b)
+
+        let xVal = 0.4124564 * linR + 0.3575761 * linG + 0.1804375 * linB
+        let yVal = 0.2126729 * linR + 0.7151522 * linG + 0.0721750 * linB
+        let zVal = 0.0193339 * linR + 0.1191920 * linG + 0.9503041 * linB
+
+        let sumXYZ = xVal + yVal + zVal
+        let temperature: Double
+        if sumXYZ <= 1e-6 {
+            temperature = 6504.0
+        } else {
+            let chrX = xVal / sumXYZ
+            let chrY = yVal / sumXYZ
+            let denom = 0.1858 - chrY
+            if abs(denom) < 1e-6 {
+                temperature = 6504.0
+            } else {
+                let n = (chrX - 0.3320) / denom
+                let cct = 437.0 * pow(n, 3) + 3601.0 * pow(n, 2) + 6861.0 * n + 5517.0
+                temperature = max(1000, min(25000, cct))
+            }
+        }
+
+        let patternLoad = min(1.0, 0.7 * (weave / 0.35) + 0.3 * (blotch / 0.40))
+
+        // Grade the contrast retained relative to a bare screen's 21:1
+        // white-on-black baseline. Absolute WCAG thresholds are not useful
+        // here: the clamped veil can never push contrast below about 9.6:1.
+        let contrastRetention = contrastRatio / 21.0
+        let grade: Grade
+        if contrastRetention >= 0.85 {
+            grade = .excellent
+        } else if contrastRetention >= 0.70 {
+            grade = .good
+        } else if contrastRetention >= 0.55 {
+            grade = .reduced
+        } else {
+            grade = .poor
+        }
+
+        return PaperComfort(
+            veil: veil,
+            dimming: dimming,
+            contrastRatio: contrastRatio,
+            blueReduction: blueReduction,
+            temperature: temperature,
+            patternLoad: patternLoad,
+            grade: grade
+        )
+    }
+
+    /// Curated starting points designed for specific viewing scenarios.
+    static let recipes: [ComfortRecipe] = [
+        ComfortRecipe(
+            id: "focus",
+            name: "Focus",
+            detail: "Near-neutral, keeps text crispest",
+            tint: (r: 0.98, g: 0.97, b: 0.96),
+            wash: 0.18,
+            weave: 0.00,
+            blotch: 0.00
+        ),
+        ComfortRecipe(
+            id: "reading",
+            name: "Reading",
+            detail: "Warm off-white for long sessions",
+            tint: (r: 0.97, g: 0.94, b: 0.88),
+            wash: 0.32,
+            weave: 0.06,
+            blotch: 0.05
+        ),
+        ComfortRecipe(
+            id: "paper",
+            name: "Paper",
+            detail: "Classic warm laid stock",
+            tint: (r: 0.95, g: 0.92, b: 0.86),
+            wash: 0.40,
+            weave: 0.18,
+            blotch: 0.12
+        ),
+        ComfortRecipe(
+            id: "night",
+            name: "Night",
+            detail: "Deep amber, strongest blue cut",
+            tint: (r: 0.96, g: 0.82, b: 0.60),
+            wash: 0.50,
+            weave: 0.00,
+            blotch: 0.10
+        )
+    ]
+}
+
+/// A curated starting configuration for custom papers.
+struct ComfortRecipe: Identifiable {
+    let id: String
+    let name: String
+    let detail: String
+    let tint: (r: Double, g: Double, b: Double)
+    let wash: Double
+    let weave: Double
+    let blotch: Double
+
+    /// Overwrites only the six visual fields — `id`, `name`, `seed` and
+    /// `engineVersion` are the paper's identity and survive.
+    func apply(to paper: inout CustomPaper) {
+        paper.tintRed = tint.r
+        paper.tintGreen = tint.g
+        paper.tintBlue = tint.b
+        paper.wash = wash
+        paper.weave = weave
+        paper.blotch = blotch
+    }
+}

--- a/Sources/Deckle/PaperMill.swift
+++ b/Sources/Deckle/PaperMill.swift
@@ -144,31 +144,138 @@ extension TexturePreset {
     }
 }
 
-/// The Paper Mill: a small standalone editor window for creating and editing
-/// custom papers, with a live preview rendered by the real engine.
+/// The Paper Mill: standalone editor window for creating and editing
+/// custom papers, with live on-screen preview, eye-comfort readouts, and non-overlapping positioning.
 @MainActor
-final class PaperMill {
+final class PaperMill: NSObject, NSWindowDelegate, ObservableObject {
     static let shared = PaperMill()
+    @Published private(set) var isOpen: Bool = false
     private var window: NSWindow?
 
+    func toggle(editing paper: CustomPaper? = nil) {
+        if isOpen, window != nil {
+            close()
+        } else {
+            open(editing: paper)
+        }
+    }
+
+    func close() {
+        AppState.shared.previewPaper = nil
+        window?.close()
+        window = nil
+        isOpen = false
+    }
+
     func open(editing paper: CustomPaper? = nil) {
+        present(
+            draft: paper ?? CustomPaper(),
+            isNew: paper == nil,
+            title: paper == nil ? "New Paper" : "Edit Paper"
+        )
+    }
+
+    /// Opens the editor pre-filled with `paper` as a brand-new unsaved draft:
+    /// a fresh id and seed, and nothing written to `customPapers` until the
+    /// user hits Create.
+    func compose(from paper: CustomPaper) {
+        var draft = paper
+        draft.id = "custom-\(UUID().uuidString.lowercased())"
+        draft.seed = .random(in: .min ... .max)
+        present(
+            draft: draft,
+            isNew: true,
+            title: "New Paper"
+        )
+    }
+
+    private func present(draft: CustomPaper, isNew: Bool, title: String) {
         window?.close()
         let editor = PaperMillView(
-            draft: paper ?? CustomPaper(),
-            isNew: paper == nil
+            draft: draft,
+            isNew: isNew
         ) { [weak self] in
-            self?.window?.close()
-            self?.window = nil
+            self?.close()
         }
         let hosting = NSHostingController(rootView: editor)
         let window = NSWindow(contentViewController: hosting)
-        window.title = paper == nil ? "New Paper" : "Edit Paper"
-        window.styleMask = [.titled, .closable]
+        window.title = title
+        window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
         window.isReleasedWhenClosed = false
-        window.center()
+        window.level = .floating
+        window.minSize = NSSize(width: 400, height: 500)
+        window.delegate = self
+
+        // Position beside the actual MenuBarExtra content window. Generic
+        // panels include the colour picker and the status-item host itself.
+        if let menuWindow = NSApp.windows.first(where: {
+            String(describing: type(of: $0)).contains("MenuBarExtra")
+                && $0.isVisible
+                && $0.frame.width > 100
+        }) {
+            let spacing: CGFloat = 12
+            let screen = NSScreen.screens.first { $0.frame.intersects(menuWindow.frame) } ?? NSScreen.main
+            let bounds = screen?.visibleFrame ?? menuWindow.frame
+            let targetWidth = min(430, bounds.width)
+            let targetHeight = min(bounds.height, min(720, max(580, menuWindow.frame.height)))
+            let leftX = menuWindow.frame.minX - targetWidth - spacing
+            let rightX = menuWindow.frame.maxX + spacing
+            let targetX: CGFloat
+            if leftX >= bounds.minX {
+                targetX = leftX
+            } else if rightX + targetWidth <= bounds.maxX {
+                targetX = rightX
+            } else {
+                targetX = min(max(bounds.minX, leftX), bounds.maxX - targetWidth)
+                menuWindow.orderOut(nil)
+            }
+            let targetY = min(
+                max(bounds.minY, menuWindow.frame.maxY - targetHeight),
+                bounds.maxY - targetHeight
+            )
+            window.setFrame(
+                NSRect(x: targetX, y: targetY, width: targetWidth, height: targetHeight),
+                display: true
+            )
+        } else {
+            window.center()
+        }
+
+        window.orderFrontRegardless()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
         self.window = window
+        self.isOpen = true
+    }
+
+    /// Closing the editor by any route — Cancel, Save, Delete or the window's
+    /// own close button — tears the preview down.
+    func windowWillClose(_ notification: Notification) {
+        AppState.shared.previewPaper = nil
+        window = nil
+        isOpen = false
+    }
+}
+
+private struct PaperMillThumbnail: View, Equatable {
+    let preset: TexturePreset
+    let isAdjusting: Bool
+
+    static func == (lhs: PaperMillThumbnail, rhs: PaperMillThumbnail) -> Bool {
+        lhs.preset == rhs.preset && lhs.isAdjusting == rhs.isAdjusting
+    }
+
+    var body: some View {
+        Image(nsImage: TextureRenderer.preview(
+            for: preset,
+            size: CGSize(width: 380, height: 130),
+            backingScale: isAdjusting ? 1 : 2,
+            cached: false
+        ))
+        .resizable()
+        .aspectRatio(380.0 / 130.0, contentMode: .fit)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.primary.opacity(0.15)))
     }
 }
 
@@ -177,54 +284,238 @@ private struct PaperMillView: View {
     let isNew: Bool
     let dismiss: () -> Void
 
+    @ObservedObject private var state = AppState.shared
+    @State private var isPreviewing = false
+    /// Set between a control change and the debounce firing. The thumbnail
+    /// renders at 1x while it is true so a weave/blotch drag never stalls on a
+    /// full 2x spectral synthesis.
+    @State private var isAdjusting = false
+    @State private var pushTask: Task<Void, Never>?
+
     private var previewPreset: TexturePreset { TexturePreset(custom: draft) }
+    private var comfort: PaperComfort {
+        PaperComfort.evaluate(paper: draft, intensity: state.intensity)
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Image(nsImage: TextureRenderer.preview(
-                for: previewPreset,
-                size: CGSize(width: 340, height: 120),
-                cached: false
-            ))
-            .resizable()
-            .aspectRatio(340.0 / 120.0, contentMode: .fit)
-            .clipShape(RoundedRectangle(cornerRadius: 8))
-            .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.primary.opacity(0.15)))
+        ScrollView(showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 14) {
+                PaperMillThumbnail(preset: previewPreset, isAdjusting: isAdjusting)
+                    .equatable()
 
-            TextField("Name", text: $draft.name)
-                .textFieldStyle(.roundedBorder)
+                // 2. On-Screen Live Preview Control Row
+                HStack(spacing: 10) {
+                    Button(action: togglePreview) {
+                        HStack(spacing: 6) {
+                            Image(systemName: isPreviewing ? "eye.slash.fill" : "eye.fill")
+                            Text(isPreviewing ? "Stop Preview" : "Preview on Screen")
+                                .fontWeight(.medium)
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(isPreviewing ? .green : .accentColor)
+                    .keyboardShortcut("p", modifiers: .command)
 
-            ColorPicker("Tint", selection: tintBinding, supportsOpacity: false)
+                    Text(isPreviewing
+                         ? "Live on screen — this window is under the overlay too."
+                         : "Renders the draft on every display before you save it.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
 
-            labeledSlider("Wash", value: $draft.wash, range: 0.10...0.60)
-            labeledSlider("Weave", value: $draft.weave, range: 0...0.35)
-            labeledSlider("Blotch", value: $draft.blotch, range: 0...0.40)
+                // 3. Name Field
+                TextField("Name", text: $draft.name)
+                    .textFieldStyle(.roundedBorder)
 
-            HStack {
-                if !isNew {
-                    Button("Delete", role: .destructive) {
-                        AppState.shared.customPapers.removeAll { $0.id == draft.id }
+                // 4. Comfort Recipes Row
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("Comfort Starting Points")
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.secondary)
+
+                    HStack(spacing: 6) {
+                        ForEach(PaperComfort.recipes) { recipe in
+                            Button(recipe.name) {
+                                recipe.apply(to: &draft)
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .help(recipe.detail)
+                        }
+                    }
+                }
+
+                // 5. Paper Properties & Sliders
+                ColorPicker("Tint", selection: tintBinding, supportsOpacity: false)
+
+                labeledSlider("Wash", value: $draft.wash, range: 0.10...0.60)
+                labeledSlider("Weave", value: $draft.weave, range: 0...0.35)
+                labeledSlider("Blotch", value: $draft.blotch, range: 0...0.40)
+
+                // 6. Eye Comfort Evaluation Card
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Eye Comfort & Contrast")
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.secondary)
+
+                        Spacer()
+
+                        Text(comfort.grade.rawValue)
+                            .font(.caption2)
+                            .fontWeight(.bold)
+                            .foregroundStyle(gradeColor)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(gradeColor.opacity(0.12))
+                            .clipShape(Capsule())
+                    }
+
+                    HStack(spacing: 16) {
+                        VStack(alignment: .leading, spacing: 3) {
+                            comfortMetric(label: "Brightness", value: "−\(Int((comfort.dimming * 100).rounded()))%")
+                            comfortMetric(label: "Contrast", value: String(format: "%.1f:1", comfort.contrastRatio))
+                            comfortMetric(label: "Blue Light", value: "−\(Int((comfort.blueReduction * 100).rounded()))%")
+                        }
+                        Divider()
+                        VStack(alignment: .leading, spacing: 3) {
+                            comfortMetric(label: "Tint Temp", value: "\(Int(comfort.temperature.rounded())) K (\(temperatureDescription))")
+                            comfortMetric(label: "Pattern Load", value: "\(Int((comfort.patternLoad * 100).rounded()))%")
+                            comfortMetric(label: "Veil Alpha", value: "\(Int((comfort.veil * 100).rounded()))%")
+                        }
+                    }
+
+                    if comfort.needsContrastWarning {
+                        HStack(spacing: 5) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .font(.system(size: 10))
+                                .foregroundStyle(.orange)
+                            Text("This paper removes over 30% of bare-screen contrast — lower Wash or Intensity for crisper text.")
+                                .font(.caption2)
+                                .foregroundStyle(.orange)
+                        }
+                    }
+                }
+                .padding(10)
+                .background(Color.primary.opacity(0.04))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                // 7. Live Intensity Slider
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text("Intensity")
+                            .font(.caption)
+                        Spacer()
+                        Text("\(Int(state.intensity * 100))%")
+                            .font(.caption)
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                    }
+                    Slider(
+                        value: $state.intensity,
+                        in: 0.05...0.45,
+                        onEditingChanged: { isAdjusting = $0 }
+                    )
+                    Text("Shared with the menu — the level this paper will actually be seen at.")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+
+                // 8. Bottom Action Buttons
+                HStack {
+                    if !isNew {
+                        Button("Delete", role: .destructive) {
+                            stopPreview()
+                            AppState.shared.customPapers.removeAll { $0.id == draft.id }
+                            dismiss()
+                        }
+                    }
+                    Spacer()
+                    Button("Cancel") {
+                        stopPreview()
                         dismiss()
                     }
-                }
-                Spacer()
-                Button("Cancel") { dismiss() }
-                Button(isNew ? "Create" : "Save") {
-                    var papers = AppState.shared.customPapers
-                    if let index = papers.firstIndex(where: { $0.id == draft.id }) {
-                        papers[index] = draft
-                    } else {
-                        papers.append(draft)
+                    Button(isNew ? "Create" : "Save") {
+                        stopPreview()
+                        var papers = AppState.shared.customPapers
+                        if let index = papers.firstIndex(where: { $0.id == draft.id }) {
+                            papers[index] = draft
+                        } else {
+                            papers.append(draft)
+                        }
+                        AppState.shared.customPapers = papers
+                        AppState.shared.textureID = draft.id
+                        dismiss()
                     }
-                    AppState.shared.customPapers = papers
-                    AppState.shared.textureID = draft.id
-                    dismiss()
+                    .keyboardShortcut(.defaultAction)
                 }
-                .keyboardShortcut(.defaultAction)
+            }
+            .padding(18)
+        }
+        .frame(minWidth: 400, maxWidth: 600, minHeight: 500, maxHeight: 800)
+        .onChange(of: previewPreset) { _ in
+            schedulePreviewPush()
+        }
+        .onDisappear {
+            pushTask?.cancel()
+        }
+    }
+
+    private var gradeColor: Color {
+        switch comfort.grade {
+        case .excellent, .good: return .green
+        case .reduced: return .orange
+        case .poor: return .red
+        }
+    }
+
+    private var temperatureDescription: String {
+        if comfort.temperature < 3500 {
+            return "Warm"
+        } else if comfort.temperature <= 5000 {
+            return "Neutral"
+        } else {
+            return "Cool"
+        }
+    }
+
+    private func comfortMetric(label: String, value: String) -> some View {
+        HStack {
+            Text(label + ":")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.caption2)
+                .fontWeight(.medium)
+                .monospacedDigit()
+        }
+    }
+
+    private func togglePreview() {
+        isPreviewing.toggle()
+        state.previewPaper = isPreviewing ? draft : nil
+    }
+
+    private func stopPreview() {
+        pushTask?.cancel()
+        isPreviewing = false
+        state.previewPaper = nil
+    }
+
+    private func schedulePreviewPush() {
+        isAdjusting = true
+        pushTask?.cancel()
+        pushTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(180))
+            guard !Task.isCancelled else { return }
+            isAdjusting = false
+            if isPreviewing {
+                state.previewPaper = draft
             }
         }
-        .padding(18)
-        .frame(width: 380)
     }
 
     private var tintBinding: Binding<Color> {

--- a/Sources/Deckle/PresetCardView.swift
+++ b/Sources/Deckle/PresetCardView.swift
@@ -1,0 +1,429 @@
+import SwiftUI
+import AppKit
+
+/// Category filter options for browsing presets
+enum PresetCategory: String, CaseIterable, Identifiable {
+    case all = "All"
+    case light = "Light"
+    case dark = "Dark"
+    case custom = "My Papers"
+
+    var id: String { rawValue }
+}
+
+/// A modern, tactile preset card for the carousel and grid.
+struct ModernPresetCard: View {
+    let preset: TexturePreset
+    let isSelected: Bool
+    var isCustom: Bool = false
+    var customPaper: CustomPaper? = nil
+    var onOpenMill: ((CustomPaper, Bool) -> Void)? = nil
+    let action: () -> Void
+
+    @EnvironmentObject private var state: AppState
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 8) {
+                // Top Preview Image
+                ZStack(alignment: .topTrailing) {
+                    Image(nsImage: TextureRenderer.preview(
+                        for: preset,
+                        size: CGSize(width: 96, height: 54)
+                    ))
+                    .resizable()
+                    .aspectRatio(16/9, contentMode: .fill)
+                    .frame(height: 52)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                    // Selected checkmark or custom indicator
+                    if isSelected {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 13, weight: .bold))
+                            .foregroundStyle(Color.white)
+                            .shadow(color: .black.opacity(0.4), radius: 2)
+                            .padding(4)
+                    }
+                }
+
+                // Text labels
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(preset.name)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(isSelected ? Color.primary : Color.primary.opacity(0.85))
+                        .lineLimit(1)
+
+                    Text(tagText)
+                        .font(.system(size: 10, weight: .regular))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .padding(.horizontal, 2)
+            }
+            .padding(8)
+            .frame(width: 108)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isSelected ? Color.accentColor.opacity(0.09) : Color(nsColor: .controlBackgroundColor).opacity(0.75))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(
+                        isSelected ? Color.accentColor : Color.primary.opacity(0.08),
+                        lineWidth: isSelected ? 1.5 : 1
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            if let customPaper {
+                Button("Edit in Paper Mill…") {
+                    if let onOpenMill {
+                        onOpenMill(customPaper, false)
+                    } else {
+                        PaperMill.shared.open(editing: customPaper)
+                    }
+                }
+                Button("Export Paper…") {
+                    PaperFiles.export(customPaper)
+                }
+                Divider()
+                Button("Delete", role: .destructive) {
+                    state.customPapers.removeAll { $0.id == customPaper.id }
+                }
+            } else {
+                Button("Duplicate in Paper Mill…") {
+                    let duplicate = CustomPaper(
+                        name: "\(preset.name) Copy",
+                        tintRed: Double(preset.tint.redComponent),
+                        tintGreen: Double(preset.tint.greenComponent),
+                        tintBlue: Double(preset.tint.blueComponent),
+                        wash: Double(preset.tintAlpha),
+                        weave: Double(preset.weave?.amplitude ?? 0),
+                        blotch: Double(preset.octaves.first(where: { $0.cell == 16 })?.weight ?? 0),
+                        engineVersion: preset.engineVersion,
+                        seed: preset.seed
+                    )
+                    if let onOpenMill {
+                        onOpenMill(duplicate, true)
+                    } else {
+                        PaperMill.shared.compose(from: duplicate)
+                    }
+                }
+            }
+        }
+        .help(preset.subtitle)
+    }
+
+    private var tagText: String {
+        if isCustom {
+            return "Custom"
+        } else if preset.isDark {
+            return "Dark paper"
+        } else if preset.weave != nil {
+            return "Woven"
+        } else {
+            return preset.subtitle.components(separatedBy: ",").first ?? "Smooth"
+        }
+    }
+}
+
+/// Collection section containing the preset carousel or full multi-column grid,
+/// with search filtering, category tabs, and clear scroll affordances (floating arrows and edge fades).
+struct PresetCollectionView: View {
+    @EnvironmentObject private var state: AppState
+    @Binding var searchText: String
+    var onOpenMill: ((CustomPaper, Bool) -> Void)? = nil
+    @State private var selectedCategory: PresetCategory = .all
+    @State private var isShowingAllGrid: Bool = false
+    @State private var scrollIndex: Int = 0
+
+    private var normalizedQuery: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private var isSearching: Bool { !normalizedQuery.isEmpty }
+
+    private var filteredPresets: [TexturePreset] {
+        let customPresets = state.customPapers.map { TexturePreset(custom: $0) }
+
+        if isSearching {
+            let customIDs = Set(state.customPapers.map(\.id))
+            return (TexturePreset.all + customPresets).filter { preset in
+                let tags = [
+                    preset.isDark ? "dark black" : "light white",
+                    preset.weave != nil ? "weave woven cotton" : "smooth",
+                    customIDs.contains(preset.id) ? "custom my paper" : "built in"
+                ].joined(separator: " ")
+                let searchable = "\(preset.name) \(preset.subtitle) \(preset.id) \(tags)".lowercased()
+                return searchable.contains(normalizedQuery)
+            }
+        }
+
+        switch selectedCategory {
+        case .all:
+            return TexturePreset.all + customPresets
+        case .light:
+            return TexturePreset.light + customPresets.filter { !$0.isDark }
+        case .dark:
+            return TexturePreset.dark + customPresets.filter(\.isDark)
+        case .custom:
+            return customPresets
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            // Header Row: "Presets" on left, "All papers >" toggle on right
+            // Header Row
+            HStack {
+                HStack(spacing: 6) {
+                    if isSearching {
+                        Text("Search Results")
+                            .font(.system(size: 13, weight: .bold))
+                            .foregroundStyle(.primary)
+                        Text("\(filteredPresets.count)")
+                            .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                            .foregroundStyle(Color.accentColor)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 1)
+                            .background(Color.accentColor.opacity(0.12))
+                            .clipShape(Capsule())
+                    } else {
+                        Text(isShowingAllGrid ? "All Papers" : "Presets")
+                            .font(.system(size: 13, weight: .bold))
+                            .foregroundStyle(.primary)
+
+                        if !isShowingAllGrid && filteredPresets.count > 2 {
+                            Text("\(filteredPresets.count)")
+                                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 1)
+                                .background(Color.primary.opacity(0.06))
+                                .clipShape(Capsule())
+                        }
+                    }
+                }
+
+                Spacer()
+
+                if isSearching {
+                    Button("Clear") {
+                        searchText = ""
+                    }
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(Color.accentColor)
+                    .buttonStyle(.plain)
+                } else {
+                    Button(action: {
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            let expanding = !isShowingAllGrid
+                            isShowingAllGrid = expanding
+                            if !expanding { selectedCategory = .all }
+                        }
+                    }) {
+                        HStack(spacing: 4) {
+                            Text(isShowingAllGrid ? "Compact" : "All papers")
+                                .font(.system(size: 12, weight: .medium))
+                            Image(systemName: isShowingAllGrid ? "chevron.up" : "chevron.right")
+                                .font(.system(size: 10, weight: .semibold))
+                        }
+                        .foregroundStyle(Color.accentColor)
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Menu {
+                    Button("New Paper…") {
+                        if let onOpenMill {
+                            onOpenMill(CustomPaper(), true)
+                        } else {
+                            PaperMill.shared.open()
+                        }
+                    }
+                    Button("Import Papers…") { PaperFiles.importPapers() }
+                    Button("Community Papers…") { CommunityBrowser.shared.open() }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+                .help("Paper actions")
+            }
+
+            // Category Filter Pills (when in All Grid or searching)
+            if isShowingAllGrid && !isSearching {
+                HStack(spacing: 6) {
+                    ForEach(PresetCategory.allCases) { category in
+                        Button(action: {
+                            withAnimation(.easeInOut(duration: 0.15)) {
+                                selectedCategory = category
+                                scrollIndex = 0
+                            }
+                        }) {
+                            Text(category.rawValue)
+                                .font(.system(size: 11, weight: selectedCategory == category ? .semibold : .regular))
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 4)
+                                .background(
+                                    Capsule()
+                                        .fill(selectedCategory == category ? Color.accentColor : Color.primary.opacity(0.06))
+                                )
+                                .foregroundStyle(selectedCategory == category ? Color.white : Color.primary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+
+                    Spacer()
+
+                    // Quick New Paper Button
+                    Button(action: {
+                        if let onOpenMill {
+                            onOpenMill(CustomPaper(), true)
+                        } else {
+                            PaperMill.shared.open()
+                        }
+                    }) {
+                        Image(systemName: "plus")
+                            .font(.system(size: 11, weight: .bold))
+                            .padding(5)
+                            .background(Circle().fill(Color.primary.opacity(0.06)))
+                    }
+                    .buttonStyle(.plain)
+                    .help("Create new custom paper")
+                }
+            }
+
+            // Carousel or Grid Content
+            if filteredPresets.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "doc.text.magnifyingglass")
+                        .font(.system(size: 24))
+                        .foregroundStyle(.tertiary)
+                    Text(isSearching ? "No papers matching \"\(normalizedQuery)\"" : "No papers found")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.secondary)
+                    if isSearching {
+                        Button("Clear Search") {
+                            searchText = ""
+                        }
+                        .controlSize(.small)
+                    } else if selectedCategory == .custom {
+                        Button("Create custom paper") {
+                            if let onOpenMill {
+                                onOpenMill(CustomPaper(), true)
+                            } else {
+                                PaperMill.shared.open()
+                            }
+                        }
+                        .controlSize(.small)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 100)
+            } else if isShowingAllGrid || isSearching {
+                // Multi-Column Grid
+                ScrollView {
+                    LazyVGrid(
+                        columns: [
+                            GridItem(.flexible(), spacing: 8),
+                            GridItem(.flexible(), spacing: 8),
+                            GridItem(.flexible(), spacing: 8)
+                        ],
+                        spacing: 8
+                    ) {
+                        ForEach(filteredPresets) { preset in
+                            let custom = state.customPapers.first { $0.id == preset.id }
+                            ModernPresetCard(
+                                preset: preset,
+                                isSelected: preset.id == state.textureID,
+                                isCustom: custom != nil,
+                                customPaper: custom,
+                                onOpenMill: onOpenMill
+                            ) {
+                                state.textureID = preset.id
+                            }
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+                .frame(maxHeight: isSearching ? 380 : 240)
+            } else {
+                // Horizontal Carousel with Interactive Scroll Affordance
+                ScrollViewReader { proxy in
+                    ZStack(alignment: .trailing) {
+                        // Horizontal Scroll View
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 8) {
+                                ForEach(Array(filteredPresets.enumerated()), id: \.element.id) { index, preset in
+                                    let custom = state.customPapers.first { $0.id == preset.id }
+                                    ModernPresetCard(
+                                        preset: preset,
+                                        isSelected: preset.id == state.textureID,
+                                        isCustom: custom != nil,
+                                        customPaper: custom,
+                                        onOpenMill: onOpenMill
+                                    ) {
+                                        state.textureID = preset.id
+                                    }
+                                    .id(index)
+                                }
+                            }
+                            .padding(.leading, 1)
+                            .padding(.trailing, 28) // Extra padding for the floating chevron
+                            .padding(.vertical, 2)
+                        }
+
+                        // A fade is useful only when three cards exceed the viewport.
+                        if filteredPresets.count > 2 {
+                            HStack {
+                                Spacer()
+                                LinearGradient(
+                                    colors: [
+                                        Color(nsColor: .windowBackgroundColor).opacity(0),
+                                        Color(nsColor: .windowBackgroundColor).opacity(0.85)
+                                    ],
+                                    startPoint: .leading,
+                                    endPoint: .trailing
+                                )
+                                .frame(width: 32)
+                                .allowsHitTesting(false)
+                            }
+                        }
+
+                        // Floating Circular Scroll Next Button (matching reference)
+                        if filteredPresets.count > 2 {
+                            Button(action: {
+                                withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                                    scrollIndex = (scrollIndex + 2) % filteredPresets.count
+                                    proxy.scrollTo(scrollIndex, anchor: .leading)
+                                }
+                            }) {
+                                ZStack {
+                                    Circle()
+                                        .fill(Color(nsColor: .controlBackgroundColor))
+                                        .frame(width: 28, height: 28)
+                                        .shadow(color: .black.opacity(0.12), radius: 4, x: 0, y: 2)
+
+                                    Image(systemName: "chevron.right")
+                                        .font(.system(size: 11, weight: .bold))
+                                        .foregroundStyle(Color.primary.opacity(0.8))
+                                }
+                                .overlay(
+                                    Circle()
+                                        .stroke(Color.primary.opacity(0.12), lineWidth: 1)
+                                )
+                            }
+                            .buttonStyle(.plain)
+                            .offset(x: -2)
+                            .help("Scroll more papers")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/Deckle/QuickControlsView.swift
+++ b/Sources/Deckle/QuickControlsView.swift
@@ -1,0 +1,445 @@
+import SwiftUI
+import AppKit
+import ServiceManagement
+
+/// Expandable fine-tuning panel for Grain parameters, Snooze timer,
+/// Multi-Display toggles, App Rules, and Preferences.
+struct QuickControlsView: View {
+    @EnvironmentObject private var state: AppState
+    @ObservedObject private var updater = UpdateManager.shared
+    @Binding var isExpanded: Bool
+    @State private var selectedTab: ControlTab = .grain
+    @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
+
+    enum ControlTab: String, CaseIterable, Identifiable {
+        case grain = "Grain"
+        case snooze = "Snooze"
+        case displays = "Displays"
+        case appRules = "App Rules"
+        case settings = "Settings"
+
+        var id: String { rawValue }
+
+        var icon: String {
+            switch self {
+            case .grain: return "slider.horizontal.2.square"
+            case .snooze: return "moon.stars.fill"
+            case .displays: return "display.2"
+            case .appRules: return "app.badge.checkmark"
+            case .settings: return "gearshape"
+            }
+        }
+    }
+
+    private var isBundled: Bool {
+        Bundle.main.bundleURL.pathExtension == "app"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Header Row with Title and Close Button
+            HStack {
+                HStack(spacing: 6) {
+                    Image(systemName: "slider.horizontal.3")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Color.accentColor)
+                    Text("Fine-Tuning & Controls")
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundStyle(.primary)
+                }
+
+                Spacer()
+
+                Button(action: {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                        isExpanded = false
+                    }
+                }) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(.secondary)
+                        .padding(4)
+                        .background(Color.primary.opacity(0.05))
+                        .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .help("Close controls")
+            }
+            .padding(.horizontal, 2)
+
+            // Horizontally scrollable Tab Pills with Scroll Fade Affordance
+            ZStack(alignment: .trailing) {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(ControlTab.allCases) { tab in
+                            Button(action: {
+                                withAnimation(.easeInOut(duration: 0.15)) {
+                                    selectedTab = tab
+                                }
+                            }) {
+                                HStack(spacing: 5) {
+                                    Image(systemName: tab.icon)
+                                        .font(.system(size: 11))
+                                    Text(tab.rawValue)
+                                        .font(.system(size: 11, weight: selectedTab == tab ? .semibold : .medium))
+                                        .fixedSize(horizontal: true, vertical: false)
+                                }
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 6)
+                                .background(
+                                    Capsule()
+                                        .fill(selectedTab == tab ? Color.accentColor : Color.primary.opacity(0.06))
+                                )
+                                .foregroundStyle(selectedTab == tab ? Color.white : Color.primary)
+                                .overlay(
+                                    Capsule()
+                                        .stroke(
+                                            selectedTab == tab ? Color.accentColor.opacity(0.4) : Color.primary.opacity(0.04),
+                                            lineWidth: 1
+                                        )
+                                )
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.leading, 1)
+                    .padding(.trailing, 16)
+                    .padding(.vertical, 2)
+                }
+
+                // Right edge subtle fade
+                LinearGradient(
+                    colors: [
+                        Color(nsColor: .windowBackgroundColor).opacity(0),
+                        Color(nsColor: .windowBackgroundColor).opacity(0.9)
+                    ],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+                .frame(width: 20)
+                .allowsHitTesting(false)
+            }
+
+            // Tab Content Card
+            VStack(alignment: .leading, spacing: 12) {
+                switch selectedTab {
+                case .grain:
+                    grainControls
+                case .snooze:
+                    snoozeControls
+                case .displays:
+                    displaysControls
+                case .appRules:
+                    appRulesControls
+                case .settings:
+                    settingsControls
+                }
+            }
+            .padding(14)
+            .background(
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(Color(nsColor: .controlBackgroundColor).opacity(0.9))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14)
+                    .stroke(Color.primary.opacity(0.07), lineWidth: 1)
+            )
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color.primary.opacity(0.03))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(Color.primary.opacity(0.05), lineWidth: 1)
+        )
+    }
+
+    // MARK: - Grain Controls
+
+    private var grainControls: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Scale Segmented Picker
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text("Grain Scale")
+                        .font(.system(size: 12, weight: .semibold))
+                    Spacer()
+                    Text(grainScaleLabel)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+
+                Picker("", selection: $state.grainScale) {
+                    Text("Fine").tag(0.5)
+                    Text("Normal").tag(1.0)
+                    Text("Coarse").tag(2.0)
+                    Text("Grainy").tag(4.0)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+            }
+
+            Divider()
+
+            // Strength Slider
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text("Grain Visibility")
+                        .font(.system(size: 12, weight: .semibold))
+                    Spacer()
+                    Text("\(Int(state.grainStrength * 100))%")
+                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.primary.opacity(0.05))
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                }
+
+                Slider(value: $state.grainStrength, in: 0.25...2.0)
+                    .tint(.accentColor)
+            }
+        }
+        .disabled(!state.isEnabled)
+    }
+
+    private var grainScaleLabel: String {
+        switch state.grainScale {
+        case 0.5: return "0.5× (Fine)"
+        case 1.0: return "1.0× (Standard)"
+        case 2.0: return "2.0× (Coarse)"
+        case 4.0: return "4.0× (Heavy)"
+        default: return String(format: "%.1f×", state.grainScale)
+        }
+    }
+
+    // MARK: - Snooze Controls
+
+    private var snoozeControls: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if state.isSnoozed, let until = state.snoozeUntil {
+                HStack {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Currently Snoozed")
+                            .font(.system(size: 12, weight: .bold))
+                            .foregroundStyle(.orange)
+                        HStack(spacing: 4) {
+                            Text("Resuming in")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                            Text(timerInterval: Date()...until, countsDown: true)
+                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                                .foregroundStyle(.primary)
+                        }
+                    }
+
+                    Spacer()
+
+                    Button("Resume Now") {
+                        state.cancelSnooze()
+                        state.isEnabled = true
+                    }
+                    .controlSize(.small)
+                    .buttonStyle(.borderedProminent)
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Temporarily hide overlay:")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+
+                    HStack(spacing: 6) {
+                        ForEach([15, 30, 60, 120], id: \.self) { minutes in
+                            Button(action: { state.snooze(minutes: minutes) }) {
+                                Text(minutes >= 120
+                                     ? "\(minutes / 60) hours"
+                                     : (minutes >= 60 ? "\(minutes / 60) hour" : "\(minutes) min"))
+                                    .font(.system(size: 11, weight: .semibold))
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 7)
+                                    .background(Color.primary.opacity(0.06))
+                                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+                .disabled(!state.isEnabled)
+            }
+        }
+    }
+
+    // MARK: - Display Controls
+
+    private var displaysControls: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Active Displays")
+                .font(.system(size: 12, weight: .semibold))
+
+            ForEach(NSScreen.screens, id: \.self) { screen in
+                if let displayID = screen.displayID {
+                    HStack {
+                        Image(systemName: "display")
+                            .font(.system(size: 13))
+                            .foregroundStyle(.secondary)
+
+                        Toggle(screen.localizedName, isOn: displayBinding(String(displayID)))
+                            .toggleStyle(.checkbox)
+                            .font(.system(size: 12))
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+        }
+    }
+
+    private func displayBinding(_ id: String) -> Binding<Bool> {
+        Binding(
+            get: { !state.excludedDisplays.contains(id) },
+            set: { include in
+                if include {
+                    state.excludedDisplays.remove(id)
+                } else {
+                    state.excludedDisplays.insert(id)
+                }
+            }
+        )
+    }
+
+    // MARK: - App Rules Controls
+
+    private var appRulesControls: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Picker("", selection: $state.appRuleMode) {
+                Text("Everywhere").tag(AppState.AppRuleMode.everywhere)
+                Text("Except…").tag(AppState.AppRuleMode.except)
+                Text("Only…").tag(AppState.AppRuleMode.only)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+
+            if state.appRuleMode != .everywhere {
+                if state.ruleApps.isEmpty {
+                    Text("No applications configured yet.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                } else {
+                    ScrollView {
+                        VStack(spacing: 4) {
+                            ForEach(state.ruleApps) { app in
+                                HStack {
+                                    Text(app.name)
+                                        .font(.system(size: 11))
+                                    Spacer()
+                                    Button {
+                                        state.ruleApps.removeAll { $0.bundleID == app.bundleID }
+                                    } label: {
+                                        Image(systemName: "xmark.circle.fill")
+                                            .foregroundStyle(.tertiary)
+                                            .font(.system(size: 12))
+                                    }
+                                    .buttonStyle(.plain)
+                                }
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .background(Color.primary.opacity(0.04))
+                                .clipShape(RoundedRectangle(cornerRadius: 6))
+                            }
+                        }
+                    }
+                    .frame(maxHeight: 100)
+                }
+
+                HStack {
+                    Button("Add App…") { addRuleApp() }
+                        .controlSize(.small)
+
+                    Spacer()
+
+                    Text(state.appRuleMode == .except
+                         ? "Hides in listed apps"
+                         : "Shows only in listed apps")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+        .disabled(!state.isEnabled)
+    }
+
+    private func addRuleApp() {
+        let panel = NSOpenPanel()
+        panel.directoryURL = URL(fileURLWithPath: "/Applications")
+        panel.allowedContentTypes = [.applicationBundle]
+        panel.allowsMultipleSelection = true
+        panel.message = "Choose apps for the rule list"
+        guard panel.runModal() == .OK else { return }
+        for url in panel.urls {
+            guard let bundle = Bundle(url: url), let id = bundle.bundleIdentifier else { continue }
+            let name = (bundle.infoDictionary?["CFBundleDisplayName"] as? String)
+                ?? (bundle.infoDictionary?["CFBundleName"] as? String)
+                ?? url.deletingPathExtension().lastPathComponent
+            if !state.ruleApps.contains(where: { $0.bundleID == id }) {
+                state.ruleApps.append(.init(bundleID: id, name: name))
+            }
+        }
+    }
+
+    // MARK: - Settings Controls
+
+    private var settingsControls: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Toggle("Hide in screenshots & screen recordings", isOn: $state.hideFromCapture)
+                .toggleStyle(.checkbox)
+                .font(.system(size: 12))
+
+            Toggle("Launch automatically at login", isOn: launchAtLoginBinding)
+                .toggleStyle(.checkbox)
+                .font(.system(size: 12))
+                .disabled(!isBundled)
+
+            Toggle("Install updates automatically", isOn: $updater.autoInstall)
+                .toggleStyle(.checkbox)
+                .font(.system(size: 12))
+
+            Divider()
+
+            HStack {
+                Button("Check for updates") {
+                    Task { await updater.check(userInitiated: true) }
+                }
+                .controlSize(.small)
+                .disabled(updater.status == .checking || updater.status == .installing)
+
+                Spacer()
+
+                Button("Quit Deckle") {
+                    NSApp.terminate(nil)
+                }
+                .controlSize(.small)
+                .buttonStyle(.plain)
+                .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private var launchAtLoginBinding: Binding<Bool> {
+        Binding(
+            get: { launchAtLogin },
+            set: { enable in
+                do {
+                    if enable {
+                        try SMAppService.mainApp.register()
+                    } else {
+                        try SMAppService.mainApp.unregister()
+                    }
+                    launchAtLogin = enable
+                } catch {
+                    launchAtLogin = SMAppService.mainApp.status == .enabled
+                }
+            }
+        )
+    }
+}

--- a/Tests/DeckleTests/PaperComfortTests.swift
+++ b/Tests/DeckleTests/PaperComfortTests.swift
@@ -1,0 +1,162 @@
+import XCTest
+@testable import Deckle
+
+final class PaperComfortTests: XCTestCase {
+    func testVeilComputationAndNearZeroVeilBaseline() {
+        let paper = CustomPaper(wash: 0.10)
+        let comfort = PaperComfort.evaluate(paper: paper, intensity: 0.05)
+        XCTAssertEqual(comfort.veil, 0.005, accuracy: 1e-9)
+        XCTAssertEqual(comfort.contrastRatio, 20.8349, accuracy: 1e-3)
+        XCTAssertLessThan(comfort.contrastRatio, 21.0)
+    }
+
+    func testContrastMonotonicallyDecreasesWithIncreasingWash() {
+        let paper1 = CustomPaper(tintRed: 0.95, tintGreen: 0.92, tintBlue: 0.86, wash: 0.10)
+        let paper2 = CustomPaper(tintRed: 0.95, tintGreen: 0.92, tintBlue: 0.86, wash: 0.35)
+        let paper3 = CustomPaper(tintRed: 0.95, tintGreen: 0.92, tintBlue: 0.86, wash: 0.60)
+
+        let intensity = 0.30
+        let c1 = PaperComfort.evaluate(paper: paper1, intensity: intensity)
+        let c2 = PaperComfort.evaluate(paper: paper2, intensity: intensity)
+        let c3 = PaperComfort.evaluate(paper: paper3, intensity: intensity)
+
+        XCTAssertGreaterThan(c1.contrastRatio, c2.contrastRatio)
+        XCTAssertGreaterThan(c2.contrastRatio, c3.contrastRatio)
+    }
+
+    func testBlueReductionUsesLinearLightAndClampedIntensity() {
+        // tintBlue = 0.5, wash = 0.4, intensity = 0.5 (clamped to 0.45)
+        // veil = 0.45 * 0.4 = 0.18; the composited blue channel is 0.91.
+        let paper = CustomPaper(tintBlue: 0.5, wash: 0.4)
+        let comfort = PaperComfort.evaluate(paper: paper, intensity: 0.5)
+
+        XCTAssertEqual(comfort.veil, 0.18, accuracy: 1e-9)
+        XCTAssertEqual(comfort.blueReduction, 0.1926540911, accuracy: 1e-9)
+    }
+
+    func testPureWhiteTintHasZeroBlueReductionAndD65Temperature() {
+        let paper = CustomPaper(tintRed: 1.0, tintGreen: 1.0, tintBlue: 1.0, wash: 0.40)
+        let comfort = PaperComfort.evaluate(paper: paper, intensity: 0.25)
+
+        XCTAssertEqual(comfort.blueReduction, 0.0, accuracy: 1e-9)
+        XCTAssertEqual(comfort.temperature, 6504.0, accuracy: 100.0)
+    }
+
+    func testWhiteTintMaxVeilHasWorstReachableContrastGrade() {
+        let paper = CustomPaper(tintRed: 1.0, tintGreen: 1.0, tintBlue: 1.0, wash: 0.60)
+        let comfort = PaperComfort.evaluate(paper: paper, intensity: 0.45)
+
+        XCTAssertEqual(comfort.veil, 0.27, accuracy: 1e-9)
+        XCTAssertEqual(comfort.contrastRatio, 9.61, accuracy: 0.10)
+        XCTAssertEqual(comfort.grade, .poor)
+        XCTAssertTrue(comfort.needsContrastWarning)
+    }
+
+    func testEveryComfortGradeIsReachable() {
+        func whitePaper(wash: Double) -> CustomPaper {
+            CustomPaper(tintRed: 1, tintGreen: 1, tintBlue: 1, wash: wash)
+        }
+
+        let excellent = PaperComfort.evaluate(paper: whitePaper(wash: 0.10), intensity: 0.05)
+        let good = PaperComfort.evaluate(paper: whitePaper(wash: 0.40), intensity: 0.25)
+        let reduced = PaperComfort.evaluate(paper: whitePaper(wash: 0.50), intensity: 0.40)
+        let poor = PaperComfort.evaluate(paper: whitePaper(wash: 0.60), intensity: 0.45)
+
+        XCTAssertEqual(excellent.grade, .excellent)
+        XCTAssertEqual(good.grade, .good)
+        XCTAssertEqual(reduced.grade, .reduced)
+        XCTAssertEqual(poor.grade, .poor)
+        XCTAssertFalse(excellent.needsContrastWarning)
+        XCTAssertFalse(good.needsContrastWarning)
+        XCTAssertTrue(reduced.needsContrastWarning)
+        XCTAssertTrue(poor.needsContrastWarning)
+    }
+
+    func testDimmingAndPatternLoadValues() {
+        let dark = CustomPaper(
+            tintRed: 0,
+            tintGreen: 0,
+            tintBlue: 0,
+            wash: 0.60,
+            weave: 0.35,
+            blotch: 0
+        )
+        let comfort = PaperComfort.evaluate(paper: dark, intensity: 0.45)
+        XCTAssertEqual(comfort.dimming, 0.508095, accuracy: 1e-4)
+        XCTAssertEqual(comfort.patternLoad, 0.7, accuracy: 1e-9)
+
+        let white = CustomPaper(
+            tintRed: 1,
+            tintGreen: 1,
+            tintBlue: 1,
+            wash: 0.60,
+            weave: 0,
+            blotch: 0.40
+        )
+        let bright = PaperComfort.evaluate(paper: white, intensity: 0.45)
+        XCTAssertEqual(bright.dimming, 0, accuracy: 1e-9)
+        XCTAssertEqual(bright.patternLoad, 0.3, accuracy: 1e-9)
+    }
+
+    func testInputClampingProducesIdenticalEvaluation() {
+        let unclamped = CustomPaper(
+            tintRed: -1.0,
+            tintGreen: 2.0,
+            tintBlue: 1.5,
+            wash: 5.0,
+            weave: 9.0,
+            blotch: -3.0
+        )
+        let clampedExpected = CustomPaper(
+            tintRed: 0.0,
+            tintGreen: 1.0,
+            tintBlue: 1.0,
+            wash: 0.60,
+            weave: 0.35,
+            blotch: 0.0
+        )
+
+        let eval1 = PaperComfort.evaluate(paper: unclamped, intensity: 0.30)
+        let eval2 = PaperComfort.evaluate(paper: clampedExpected, intensity: 0.30)
+
+        XCTAssertEqual(eval1.veil, eval2.veil, accuracy: 1e-9)
+        XCTAssertEqual(eval1.dimming, eval2.dimming, accuracy: 1e-9)
+        XCTAssertEqual(eval1.contrastRatio, eval2.contrastRatio, accuracy: 1e-9)
+        XCTAssertEqual(eval1.blueReduction, eval2.blueReduction, accuracy: 1e-9)
+        XCTAssertEqual(eval1.temperature, eval2.temperature, accuracy: 1e-9)
+        XCTAssertEqual(eval1.patternLoad, eval2.patternLoad, accuracy: 1e-9)
+        XCTAssertEqual(eval1.grade, eval2.grade)
+    }
+
+    func testComfortRecipePreservesIdentityAndAppliesVisuals() {
+        var paper = CustomPaper(
+            id: "custom-special-id-123",
+            name: "My Unsaved Custom Paper",
+            tintRed: 0.1,
+            tintGreen: 0.2,
+            tintBlue: 0.3,
+            wash: 0.15,
+            weave: 0.05,
+            blotch: 0.05,
+            engineVersion: .spectral,
+            seed: 987654321
+        )
+
+        let recipe = PaperComfort.recipes.first { $0.id == "night" }!
+        recipe.apply(to: &paper)
+
+        // Identity must be preserved
+        XCTAssertEqual(paper.id, "custom-special-id-123")
+        XCTAssertEqual(paper.name, "My Unsaved Custom Paper")
+        XCTAssertEqual(paper.seed, 987654321)
+        XCTAssertEqual(paper.engineVersion, .spectral)
+
+        // Visuals must match recipe
+        XCTAssertEqual(paper.tintRed, recipe.tint.r, accuracy: 1e-9)
+        XCTAssertEqual(paper.tintGreen, recipe.tint.g, accuracy: 1e-9)
+        XCTAssertEqual(paper.tintBlue, recipe.tint.b, accuracy: 1e-9)
+        XCTAssertEqual(paper.wash, recipe.wash, accuracy: 1e-9)
+        XCTAssertEqual(paper.weave, recipe.weave, accuracy: 1e-9)
+        XCTAssertEqual(paper.blotch, recipe.blotch, accuracy: 1e-9)
+    }
+}


### PR DESCRIPTION
## Summary
- redesign the menu-bar popover with searchable paper cards, explicit scroll affordances, notifications, and consolidated controls
- add live on-screen Paper Mill previews with safe window lifecycle, multi-display placement, and unsaved-draft handling
- add contrast-retention, dimming, blue-channel, temperature, and pattern-load guidance with curated comfort recipes
- retain stable import/community entry points and restore Community Browser loading
- harden update, snooze, search, category-filter, and Paper Mill toggle edge cases found during review

## Verification
- `swift test` — 18 tests passed
- `make app` — release bundle built and ad-hoc signed
- native smoke test — search, controls-during-search, adjacent Paper Mill placement, and Open/Close Mill toggle exercised
