### PR TITLE
Fix All Papers popover resize artifact

### DIFF
--- a/Sources/Deckle/MenuView.swift
+++ b/Sources/Deckle/MenuView.swift
@@ -8,6 +8,7 @@ struct MenuView: View {
     @EnvironmentObject private var state: AppState
     @ObservedObject private var updater = UpdateManager.shared
     @State private var searchText = ""
+    @State private var isShowingAllPapers = false
     @ObservedObject private var mill = PaperMill.shared
     @State private var isDetailsExpanded = false
     @State private var showNotificationSheet = false
@@ -39,7 +40,7 @@ struct MenuView: View {
                     ))
             }
 
-            if !isSearching {
+            if !isLibraryFocused {
                 HeroCardView(isDetailsExpanded: $isDetailsExpanded)
             }
 
@@ -49,7 +50,7 @@ struct MenuView: View {
                     .transition(.opacity.combined(with: .move(edge: .top)))
             }
 
-            if !isSearching && !isDetailsExpanded {
+            if !isLibraryFocused && !isDetailsExpanded {
                 FeaturePromoCard {
                     PaperMill.shared.open()
                 }
@@ -58,6 +59,7 @@ struct MenuView: View {
             // 7. Preset Carousel / Grid
             PresetCollectionView(
                 searchText: $searchText,
+                isShowingAllGrid: $isShowingAllPapers,
                 onOpenMill: { paper, isNew in
                     if isNew {
                         PaperMill.shared.compose(from: paper)
@@ -72,11 +74,19 @@ struct MenuView: View {
         }
         .padding(14)
         .frame(width: 370)
+        .fixedSize(horizontal: false, vertical: true)
         .background(Color(nsColor: .windowBackgroundColor).opacity(0.96))
         .animation(.spring(response: 0.32, dampingFraction: 0.82), value: isDetailsExpanded)
         .animation(.easeInOut(duration: 0.2), value: isSearching)
+        .animation(.easeOut(duration: 0.2), value: isShowingAllPapers)
         .animation(.spring(response: 0.3, dampingFraction: 0.8), value: showNotificationSheet)
         .animation(.spring(response: 0.3, dampingFraction: 0.8), value: dismissedUpdateVersion)
+        .onChange(of: isShowingAllPapers) { expanded in
+            if expanded {
+                isDetailsExpanded = false
+                isSearchFocused = false
+            }
+        }
     }
 
     // MARK: - 1. Top Header Bar (Matching Reference Design)
@@ -192,6 +202,10 @@ struct MenuView: View {
 
     private var isSearching: Bool {
         !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var isLibraryFocused: Bool {
+        isSearching || isShowingAllPapers
     }
 
     // MARK: - 2. Search Bar

--- a/Sources/Deckle/PresetCardView.swift
+++ b/Sources/Deckle/PresetCardView.swift
@@ -133,9 +133,9 @@ struct ModernPresetCard: View {
 struct PresetCollectionView: View {
     @EnvironmentObject private var state: AppState
     @Binding var searchText: String
+    @Binding var isShowingAllGrid: Bool
     var onOpenMill: ((CustomPaper, Bool) -> Void)? = nil
     @State private var selectedCategory: PresetCategory = .all
-    @State private var isShowingAllGrid: Bool = false
     @State private var scrollIndex: Int = 0
 
     private var normalizedQuery: String {
@@ -143,6 +143,16 @@ struct PresetCollectionView: View {
     }
 
     private var isSearching: Bool { !normalizedQuery.isEmpty }
+
+    private var gridViewportHeight: CGFloat {
+        let rowCount = max(1, (filteredPresets.count + 2) / 3)
+        let cardHeight: CGFloat = 108
+        let rowSpacing: CGFloat = 8
+        let contentHeight = CGFloat(rowCount) * cardHeight
+            + CGFloat(max(0, rowCount - 1)) * rowSpacing
+            + 4
+        return min(isSearching ? 360 : 236, max(cardHeight + 4, contentHeight))
+    }
 
     private var filteredPresets: [TexturePreset] {
         let customPresets = state.customPapers.map { TexturePreset(custom: $0) }
@@ -217,7 +227,7 @@ struct PresetCollectionView: View {
                     .buttonStyle(.plain)
                 } else {
                     Button(action: {
-                        withAnimation(.easeInOut(duration: 0.25)) {
+                        withAnimation(.easeOut(duration: 0.2)) {
                             let expanding = !isShowingAllGrid
                             isShowingAllGrid = expanding
                             if !expanding { selectedCategory = .all }
@@ -350,7 +360,8 @@ struct PresetCollectionView: View {
                     }
                     .padding(.vertical, 2)
                 }
-                .frame(maxHeight: isSearching ? 380 : 240)
+                .frame(height: gridViewportHeight)
+                .layoutPriority(1)
             } else {
                 // Horizontal Carousel with Interactive Scroll Affordance
                 ScrollViewReader { proxy in

--- a/Support/Info.plist
+++ b/Support/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.0</string>
+	<string>1.7.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Problem

On macOS Tahoe 26.6.2, switching Deckle 1.7.0 to **All Papers** could leave the MenuBarExtra's translucent material at the previous size. The stale region appeared as a ghost outline and made the lower corners look square.

## Changes

- Lift the All Papers state into `MenuView` so focused library mode can hide the competing hero and promo surfaces.
- Give the vertical grid a deterministic, row-aware viewport height instead of a compressible `maxHeight`.
- Size the popover root to its current vertical content and use the existing 200 ms ease-out transition.
- Reset hidden controls state when entering All Papers.
- Bump Deckle to **1.7.1** (build **14**).

## Verification

- `plutil -lint Support/Info.plist` — OK
- `swift test` — 18 tests passed, 0 failures
- `make build UNIVERSAL=1` — arm64 and x86_64 release build passed
- Built and launched `dist/Deckle.app`, then exercised **All Papers → Compact** through the real menu-bar UI. All four corners remained rounded; no stale translucent footprint or blank material remained below the footer in either state.

The AppKit/MenuBarExtra window behavior has no useful deterministic unit-test seam, so this regression was verified against the actual bundled app.

Fixed #27 