### PR TITLE
Fix blank bands around the expanded paper library

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Not a calibrated blue-light filter — a *matte texture* overlay. The grain brea
   - *Papers* — Soft Wove, Rice Paper, Laid Cotton, Newsprint, Cold Press, Artist Canvas, Felt Side, Frost Glassine
   - *Warm & tinted* — Foxed Amber, Bookcloth, Recycled Kraft, Plum Kozo, Rose Quartz, Sage Press, Nordic Sky
   - *Dark* — Ink Stone, Midnight Slate, Espresso
-- **Searchable paper library** — search names, descriptions, IDs, and material terms; filter by light, dark, or custom papers; use the edge fade and arrow to browse the compact carousel
+- **Searchable paper library** — search names, descriptions, IDs, and material terms; filter by light, dark, or custom papers; use the edge fade and arrow to browse the compact carousel. Opening All Papers or searching resizes the menu immediately to fit its content
 - **Paper Mill with live screen preview** — tune tint, wash, weave, and blotch against your actual desktop before creating or saving the paper
 - **Comfort guidance** — see contrast retention, estimated brightness and blue-channel reduction, tint temperature, pattern load, and four starting recipes: Focus, Reading, Paper, and Night
 - **Paper portability** — export custom papers as JSON, import them later, or install shared recipes from the [community papers repo](https://github.com/YellowFoxH4XOR/deckle-papers)

--- a/Sources/Deckle/MenuView.swift
+++ b/Sources/Deckle/MenuView.swift
@@ -77,9 +77,10 @@ struct MenuView: View {
         .fixedSize(horizontal: false, vertical: true)
         .background(Color(nsColor: .windowBackgroundColor).opacity(0.96))
         .animation(.spring(response: 0.32, dampingFraction: 0.82), value: isDetailsExpanded)
-        .animation(.easeInOut(duration: 0.2), value: isSearching)
-        .animation(.easeOut(duration: 0.2), value: isShowingAllPapers)
         .animation(.spring(response: 0.3, dampingFraction: 0.8), value: dismissedUpdateVersion)
+        // MenuBarExtra sizes its native window from the content's fitting size.
+        // Animate neither side of a library switch through intermediate heights.
+        .animation(nil, value: isLibraryFocused)
         .onChange(of: isShowingAllPapers) { expanded in
             if expanded {
                 isDetailsExpanded = false

--- a/Sources/Deckle/PresetCardView.swift
+++ b/Sources/Deckle/PresetCardView.swift
@@ -227,11 +227,9 @@ struct PresetCollectionView: View {
                     .buttonStyle(.plain)
                 } else {
                     Button(action: {
-                        withAnimation(.easeOut(duration: 0.2)) {
-                            let expanding = !isShowingAllGrid
-                            isShowingAllGrid = expanding
-                            if !expanding { selectedCategory = .all }
-                        }
+                        let expanding = !isShowingAllGrid
+                        isShowingAllGrid = expanding
+                        if !expanding { selectedCategory = .all }
                     }) {
                         HStack(spacing: 4) {
                             Text(isShowingAllGrid ? "Compact" : "All papers")


### PR DESCRIPTION
Opening All Papers can leave blank bands above and below the menu content. This change removes the explicit expansion animation and disables animation when switching between the dashboard and library, so MenuBarExtra receives the final content height immediately. The paper grid layout stays unchanged, and the README describes the immediate resizing behavior.

Validation:

- `swift test` — passed, 18 tests with zero failures.
- `make app` — passed; built and ad-hoc signed `dist/Deckle.app`.
- `make build UNIVERSAL=1` — passed for arm64 and x86_64.
- `git diff --check` — passed.

The rebuilt bundle was launched, but visual confirmation and an updated screenshot remain pending: the UI automation tool exposed only an empty window and could not access the menu-bar popover. Before merging, open All Papers, return to Compact, and enter/clear a search to confirm the blank bands are gone. The builds report two existing unused `try?` result warnings in `UpdateManager.swift`.
