### PR TITLE
docs: add Deckle design system reference

### DIFF
--- a/DESIGN.json
+++ b/DESIGN.json
@@ -1,0 +1,161 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-08-29T20:28:55Z",
+  "title": "Design System: Deckle",
+  "extensions": {
+    "colorMeta": {
+      "brand-rust": {
+        "role": "primary",
+        "displayName": "Deckle Rust",
+        "canonical": "#B34A22",
+        "tonalRamp": ["#2D1009", "#4C1B0F", "#702819", "#963720", "#B34A22", "#CC7355", "#E6A891", "#F7DED3"]
+      },
+      "action-blue": {
+        "role": "primary",
+        "displayName": "Action Blue",
+        "canonical": "#007AFF",
+        "tonalRamp": ["#001A35", "#003A70", "#0057A8", "#007AFF", "#409CFF", "#80BDFF", "#BFDEFF", "#EAF5FF"]
+      },
+      "success-green": {
+        "role": "secondary",
+        "displayName": "Success Green",
+        "canonical": "#34C759",
+        "tonalRamp": ["#0B2B13", "#145124", "#1E7A36", "#28A348", "#34C759", "#6AD881", "#A0E9AC", "#E1F8E6"]
+      },
+      "warning-orange": {
+        "role": "secondary",
+        "displayName": "Warning Orange",
+        "canonical": "#FF9500",
+        "tonalRamp": ["#351F00", "#704100", "#A86100", "#DF8200", "#FF9500", "#FFB340", "#FFD180", "#FFF0D4"]
+      },
+      "window-light": {
+        "role": "neutral",
+        "displayName": "Quiet Window",
+        "canonical": "#F5F5F7",
+        "tonalRamp": ["#242426", "#414145", "#626267", "#85858B", "#AEAEB4", "#D1D1D6", "#E8E8EC", "#F5F5F7"]
+      },
+      "label-light": {
+        "role": "neutral",
+        "displayName": "Ink Label",
+        "canonical": "#1D1D1F",
+        "tonalRamp": ["#1D1D1F", "#343438", "#515157", "#6E6E73", "#8E8E93", "#AEAEB2", "#D1D1D6", "#F5F5F7"]
+      }
+    },
+    "typographyMeta": {
+      "headline": { "displayName": "Paper Headline", "purpose": "Selected paper names in the hero." },
+      "title": { "displayName": "Panel Title", "purpose": "Library, editor, and drawer titles." },
+      "body": { "displayName": "Control Body", "purpose": "Buttons, status, and paper names." },
+      "label": { "displayName": "Utility Label", "purpose": "Chips, sections, and slider labels." },
+      "micro": { "displayName": "Supporting Copy", "purpose": "Descriptions and compact help." },
+      "mono": { "displayName": "Stable Metric", "purpose": "Percentages, timers, counts, and engine metadata." }
+    },
+    "shadows": [
+      { "name": "control-lift", "value": "0 1px 2px rgba(0, 0, 0, 0.04)", "purpose": "Circular toolbar controls and compact capsules." },
+      { "name": "texture-lift", "value": "0 1px 3px rgba(0, 0, 0, 0.08)", "purpose": "Texture preview against the hero surface." },
+      { "name": "hero-lift", "value": "0 3px 8px rgba(0, 0, 0, 0.06)", "purpose": "Primary status surface only." },
+      { "name": "paging-lift", "value": "0 2px 4px rgba(0, 0, 0, 0.12)", "purpose": "Floating carousel navigation." }
+    ],
+    "motion": [
+      { "name": "state-fast", "value": "150ms ease-in-out", "purpose": "Tab and chip selection." },
+      { "name": "mode-standard", "value": "200ms ease-out", "purpose": "Compact, All Papers, and search mode transitions." },
+      { "name": "panel-reveal", "value": "200ms ease-out", "purpose": "Notification and control disclosure without bounce." }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Capsule",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "Compact native primary action used for Open Mill and live preview.",
+      "html": "<button class=\"ds-primary-capsule\">Open Mill</button>",
+      "css": ".ds-primary-capsule { background:#007AFF; color:#FFFFFF; border:0; border-radius:999px; min-height:36px; padding:6px 14px; font:600 13px -apple-system,BlinkMacSystemFont,sans-serif; transition:background-color 150ms ease-out,transform 150ms ease-out; } .ds-primary-capsule:hover { background:#006EE6; } .ds-primary-capsule:active { transform:scale(.96); } .ds-primary-capsule:focus-visible { outline:2px solid rgba(0,122,255,.45); outline-offset:2px; }"
+    },
+    {
+      "name": "Circular Action",
+      "kind": "button",
+      "refersTo": "button-icon",
+      "description": "Neutral 36-point toolbar control for notifications and account settings.",
+      "html": "<button class=\"ds-icon-action\" aria-label=\"Notifications\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><path d=\"M18 8a6 6 0 0 0-12 0c0 7-3 7-3 9h18c0-2-3-2-3-9\"/><path d=\"M10 21h4\"/></svg></button>",
+      "css": ".ds-icon-action { width:36px; height:36px; display:grid; place-items:center; border-radius:999px; border:1px solid rgba(0,0,0,.08); background:#FFFFFF; color:#1D1D1F; box-shadow:0 1px 2px rgba(0,0,0,.04); transition:background-color 150ms ease-out,transform 150ms ease-out; } .ds-icon-action:hover { background:#F5F5F7; } .ds-icon-action:active { transform:scale(.96); } .ds-icon-action:focus-visible { outline:2px solid rgba(0,122,255,.4); outline-offset:2px; }"
+    },
+    {
+      "name": "Search Field",
+      "kind": "input",
+      "refersTo": "search-field",
+      "description": "Rounded native search field that enters a focused results mode.",
+      "html": "<label class=\"ds-search\"><svg width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\"><circle cx=\"11\" cy=\"11\" r=\"7\"/><path d=\"m20 20-3.5-3.5\"/></svg><input placeholder=\"Search all papers & textures…\"></label>",
+      "css": ".ds-search { height:40px; display:flex; align-items:center; gap:8px; padding:0 10px; border:1px solid rgba(0,0,0,.08); border-radius:12px; background:#FFFFFF; color:#6E6E73; transition:border-color 150ms ease-out; } .ds-search:focus-within { border-color:rgba(0,122,255,.5); color:#007AFF; } .ds-search input { width:100%; border:0; outline:0; background:transparent; color:#1D1D1F; font:500 13px -apple-system,BlinkMacSystemFont,sans-serif; }"
+    },
+    {
+      "name": "Filter Chip",
+      "kind": "chip",
+      "refersTo": "filter-chip",
+      "description": "Capsule category selector with explicit selected state.",
+      "html": "<button class=\"ds-filter-chip\" aria-pressed=\"true\">All</button>",
+      "css": ".ds-filter-chip { border:0; border-radius:999px; padding:4px 10px; background:#F5F5F7; color:#1D1D1F; font:600 11px -apple-system,BlinkMacSystemFont,sans-serif; transition:background-color 150ms ease-out,transform 150ms ease-out; } .ds-filter-chip[aria-pressed=\"true\"] { background:#B34A22; color:#FFFFFF; } .ds-filter-chip:active { transform:scale(.96); } .ds-filter-chip:focus-visible { outline:2px solid rgba(179,74,34,.35); outline-offset:2px; }"
+    },
+    {
+      "name": "Hero Status Surface",
+      "kind": "card",
+      "refersTo": "hero-card",
+      "description": "The single raised summary surface for current paper and intensity.",
+      "html": "<section class=\"ds-hero\"><span class=\"ds-meta\">ENGINE V2 · ACTIVE</span><h2>Soft Wove</h2><p>Active</p><button>Pause texture</button></section>",
+      "css": ".ds-hero { padding:16px; border:1px solid rgba(0,0,0,.08); border-radius:18px; background:#FFFFFF; color:#1D1D1F; box-shadow:0 3px 8px rgba(0,0,0,.06); font-family:-apple-system,BlinkMacSystemFont,sans-serif; } .ds-hero h2 { margin:12px 0 2px; font-size:19px; line-height:1.2; } .ds-hero p { margin:0; color:#34C759; font-size:13px; } .ds-hero button { width:100%; margin-top:14px; min-height:38px; border:1px solid rgba(0,0,0,.10); border-radius:999px; background:#F5F5F7; font-weight:600; } .ds-hero button:focus-visible { outline:2px solid rgba(0,122,255,.4); outline-offset:2px; } .ds-meta { color:#6E6E73; font:600 10px ui-monospace,SFMono-Regular,monospace; }"
+    },
+    {
+      "name": "Paper Card",
+      "kind": "card",
+      "refersTo": "paper-card",
+      "description": "Fixed-width tactile preview used in both carousel and three-column grid.",
+      "html": "<button class=\"ds-paper-card\" aria-pressed=\"true\"><span class=\"ds-paper-texture\"></span><strong>Soft Wove</strong><small>Smooth</small></button>",
+      "css": ".ds-paper-card { width:108px; padding:8px; display:grid; gap:8px; text-align:left; border:1.5px solid #B34A22; border-radius:12px; background:rgba(179,74,34,.09); color:#1D1D1F; font-family:-apple-system,BlinkMacSystemFont,sans-serif; transition:background-color 150ms ease-out,transform 150ms ease-out; } .ds-paper-card:hover { background:rgba(179,74,34,.13); } .ds-paper-card:active { transform:scale(.96); } .ds-paper-card:focus-visible { outline:2px solid rgba(179,74,34,.35); outline-offset:2px; } .ds-paper-card strong { font-size:12px; } .ds-paper-card small { color:#6E6E73; font-size:10px; } .ds-paper-texture { height:52px; border-radius:8px; border:1px solid rgba(0,0,0,.1); background:radial-gradient(circle at 30% 20%,#FFFFFF,#ECE8DF); }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Quiet Paper Studio",
+    "overview": "Deckle is opened briefly while someone is reading, writing, or working across one or more displays. Its controls should feel like well-kept tools on a calm desk: familiar, precise, tactile, and ready to disappear as soon as the paper is chosen.\n\nThe interface is a restrained macOS product surface. System materials and semantic colors provide adaptation; one accent identifies selection and primary action. Texture is the subject, not decoration. Dense controls remain legible without turning the popover into a dashboard.\n\nDeckle rejects ornamental glassmorphism, neon utility palettes, oversized marketing typography, nested card stacks, and motion that delays a task.",
+    "keyCharacteristics": [
+      "System-native and immediately understandable",
+      "Quiet neutral surfaces with one active accent",
+      "Paper previews as the dominant visual material",
+      "Compact controls with explicit labels and state",
+      "Focused modes instead of stacking every section vertically",
+      "Fast, interruptible transitions with no bounce"
+    ],
+    "rules": [
+      { "name": "The Focused Surface Rule", "body": "When a task expands, the competing summary surface leaves. All Papers hides the hero card; search hides summary content; Compact restores it.", "section": "overview" },
+      { "name": "The Honest Material Rule", "body": "The system window may use native translucency. Content surfaces inside it are opaque or strongly tonal. Empty translucent regions are forbidden.", "section": "overview" },
+      { "name": "The One Active Accent Rule", "body": "Accent color marks current selection, focus, or the primary action. Inactive controls stay neutral.", "section": "colors" },
+      { "name": "The Semantic State Rule", "body": "Green means active or successful, orange means caution or snoozed, and red means destructive, failed, or newly available. Never reuse those colors decoratively.", "section": "colors" },
+      { "name": "The Stable Number Rule", "body": "Every changing percentage, timer, count, and comfort metric uses monospaced or monospaced-digit typography so controls do not shift.", "section": "typography" },
+      { "name": "The Native Voice Rule", "body": "Buttons use sentence case and short verbs. Uppercase is reserved for terse engine metadata, never ordinary labels.", "section": "typography" },
+      { "name": "The Ambient Only Rule", "body": "Shadows remain diffuse and below 12% black. If an edge looks drawn or dirty, the shadow is too strong.", "section": "elevation" },
+      { "name": "The One Raised Hero Rule", "body": "The hero may be raised. Inner metric groups and control drawers use tonal separation, not another large shadow.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do use the Apple system font and native semantic colors for application UI.",
+      "Do keep the popover at 370 points with 14-point outer padding and 12-point section rhythm.",
+      "Do give every vertical `ScrollView` inside MenuBarExtra a deterministic viewport height.",
+      "Do hide the hero when All Papers or search becomes the primary task.",
+      "Do use `.fixedSize(horizontal: false, vertical: true)` at the popover root when content height changes by mode.",
+      "Do keep card dimensions explicit: 108-point paper cards, 8-point gaps, three columns.",
+      "Do use 150 to 250ms state transitions with ease-out timing and no visible bounce.",
+      "Do use monospaced digits for live percentages, countdowns, counts, and comfort metrics.",
+      "Do use checkmarks, labels, or symbols alongside semantic color.",
+      "Do show carousel fades and arrows only when content actually overflows.",
+      "Do keep Paper Mill comfort language factual and non-medical."
+    ],
+    "donts": [
+      "Don't use `.frame(maxHeight:)` alone for a flexible grid inside MenuBarExtra. It may collapse while the window keeps translucent empty space.",
+      "Don't stack the hero, control drawer, and expanded library in one vertical state.",
+      "Don't use decorative glassmorphism. Native window material is sufficient; content surfaces must remain readable and bounded.",
+      "Don't nest cards inside cards. Use spacing, dividers, and tonal groups before another container.",
+      "Don't use gradient text, neon accents, side-stripe borders, or oversized display typography.",
+      "Don't use success, warning, or danger colors outside their semantic meaning.",
+      "Don't hide a selected category when returning to Compact; reset it to All.",
+      "Don't truncate control-tab labels to make them fit. Keep the tab row scrollable and signal overflow.",
+      "Don't animate layout with spring bounce. Motion communicates a state change and then gets out of the way.",
+      "Don't leave blank material below the footer after a mode transition. If that occurs, the sizing contract is broken."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,312 @@
+---
+name: Deckle
+description: A quiet, tactile macOS control surface for making screens feel like paper.
+colors:
+  brand-rust: "#B34A22"
+  action-blue: "#007AFF"
+  success-green: "#34C759"
+  warning-orange: "#FF9500"
+  danger-red: "#FF3B30"
+  promo-purple: "#AF52DE"
+  window-light: "#F5F5F7"
+  surface-light: "#FFFFFF"
+  label-light: "#1D1D1F"
+  secondary-label-light: "#6E6E73"
+  hairline-light: "#00000014"
+  window-dark: "#1C1C1E"
+  surface-dark: "#2C2C2E"
+  label-dark: "#F5F5F7"
+  secondary-label-dark: "#AEAEB2"
+  hairline-dark: "#FFFFFF14"
+typography:
+  headline:
+    fontFamily: "-apple-system, BlinkMacSystemFont, sans-serif"
+    fontSize: "19px"
+    fontWeight: 700
+    lineHeight: 1.2
+  title:
+    fontFamily: "-apple-system, BlinkMacSystemFont, sans-serif"
+    fontSize: "15px"
+    fontWeight: 700
+    lineHeight: 1.25
+  body:
+    fontFamily: "-apple-system, BlinkMacSystemFont, sans-serif"
+    fontSize: "13px"
+    fontWeight: 500
+    lineHeight: 1.35
+  label:
+    fontFamily: "-apple-system, BlinkMacSystemFont, sans-serif"
+    fontSize: "11px"
+    fontWeight: 600
+    lineHeight: 1.25
+  micro:
+    fontFamily: "-apple-system, BlinkMacSystemFont, sans-serif"
+    fontSize: "10px"
+    fontWeight: 500
+    lineHeight: 1.2
+  mono:
+    fontFamily: "SF Mono, ui-monospace, monospace"
+    fontSize: "10px"
+    fontWeight: 600
+    lineHeight: 1.2
+rounded:
+  metric: "4px"
+  badge: "6px"
+  texture: "8px"
+  icon: "10px"
+  control: "12px"
+  panel: "14px"
+  drawer: "16px"
+  hero: "18px"
+  capsule: "999px"
+spacing:
+  hairline: "2px"
+  compact: "4px"
+  control: "6px"
+  item: "8px"
+  group: "10px"
+  section: "12px"
+  panel: "14px"
+  card: "16px"
+  window: "18px"
+components:
+  button-primary:
+    backgroundColor: "{colors.action-blue}"
+    textColor: "{colors.surface-light}"
+    typography: "{typography.body}"
+    rounded: "{rounded.capsule}"
+    padding: "6px 10px"
+    height: "36px"
+  button-icon:
+    backgroundColor: "{colors.surface-light}"
+    textColor: "{colors.label-light}"
+    rounded: "{rounded.capsule}"
+    size: "36px"
+  search-field:
+    backgroundColor: "{colors.surface-light}"
+    textColor: "{colors.label-light}"
+    typography: "{typography.body}"
+    rounded: "{rounded.control}"
+    padding: "8px 10px"
+    height: "40px"
+  hero-card:
+    backgroundColor: "{colors.surface-light}"
+    textColor: "{colors.label-light}"
+    rounded: "{rounded.hero}"
+    padding: "16px"
+  paper-card:
+    backgroundColor: "{colors.surface-light}"
+    textColor: "{colors.label-light}"
+    rounded: "{rounded.control}"
+    padding: "8px"
+    width: "108px"
+  filter-chip:
+    backgroundColor: "{colors.window-light}"
+    textColor: "{colors.label-light}"
+    typography: "{typography.label}"
+    rounded: "{rounded.capsule}"
+    padding: "4px 10px"
+  filter-chip-selected:
+    backgroundColor: "{colors.brand-rust}"
+    textColor: "{colors.surface-light}"
+    typography: "{typography.label}"
+    rounded: "{rounded.capsule}"
+    padding: "4px 10px"
+---
+
+# Design System: Deckle
+
+## Overview
+
+**Creative North Star: "The Quiet Paper Studio"**
+
+Deckle is opened briefly while someone is reading, writing, or working across one or more displays. Its controls should feel like well-kept tools on a calm desk: familiar, precise, tactile, and ready to disappear as soon as the paper is chosen.
+
+The interface is a restrained macOS product surface. System materials and semantic colors provide adaptation; one accent identifies selection and primary action. Texture is the subject, not decoration. Dense controls remain legible without turning the popover into a dashboard.
+
+Deckle rejects ornamental glassmorphism, neon utility palettes, oversized marketing typography, nested card stacks, and motion that delays a task.
+
+**Key Characteristics:**
+
+- System-native and immediately understandable
+- Quiet neutral surfaces with one active accent
+- Paper previews as the dominant visual material
+- Compact controls with explicit labels and state
+- Focused modes instead of stacking every section vertically
+- Fast, interruptible transitions with no bounce
+
+**The Focused Surface Rule.** When a task expands, the competing summary surface leaves. All Papers hides the hero card; search hides summary content; Compact restores it.
+
+**The Honest Material Rule.** The system window may use native translucency. Content surfaces inside it are opaque or strongly tonal. Empty translucent regions are forbidden.
+
+## Colors
+
+The palette is adaptive and restrained. In SwiftUI, system semantic colors remain the runtime source of truth. The fixed light and dark values above are cross-tool equivalents for documentation and generated components.
+
+### Primary
+
+- **Deckle Rust** (`brand-rust`): product identity, selected filters on branded surfaces, and documentation accents. It must not flood large regions.
+- **Action Blue** (`action-blue`): Open Mill and explicit primary actions that need the standard macOS action signal.
+
+### Secondary
+
+- **Success Green** (`success-green`): active overlay state, successful checks, and healthy preview feedback.
+- **Warning Orange** (`warning-orange`): snooze state and contrast guidance that needs attention but does not block saving.
+- **Danger Red** (`danger-red`): destructive actions, update notification dots, and errors only.
+- **Workshop Purple** (`promo-purple`): rare discovery prompts such as Paper Mill education, never core navigation.
+
+### Neutral
+
+- **Quiet Window** (`window-light`, `window-dark`): outer popover and secondary toolbar layer.
+- **Paper Surface** (`surface-light`, `surface-dark`): hero, editor, search, and control surfaces.
+- **Ink Label** (`label-light`, `label-dark`): primary text and active iconography.
+- **Soft Graphite** (`secondary-label-light`, `secondary-label-dark`): descriptions, metadata, inactive labels, and help copy.
+- **Hairline** (`hairline-light`, `hairline-dark`): one-pixel containment where tonal separation alone is insufficient.
+
+**The One Active Accent Rule.** Accent color marks current selection, focus, or the primary action. Inactive controls stay neutral.
+
+**The Semantic State Rule.** Green means active or successful, orange means caution or snoozed, and red means destructive, failed, or newly available. Never reuse those colors decoratively.
+
+## Typography
+
+**Display Font:** Apple system font
+**Body Font:** Apple system font
+**Label/Mono Font:** SF Mono for changing values and engine metadata
+
+**Character:** Native, compact, and matter-of-fact. Weight and scale establish hierarchy; font changes do not.
+
+### Hierarchy
+
+- **Headline** (700, 19px, 1.2): selected paper name inside the hero card.
+- **Title** (700, 15px, 1.25): panel and editor titles.
+- **Body** (500, 13px, 1.35): buttons, status copy, paper names, and primary controls.
+- **Label** (600, 11px, 1.25): section labels, chips, slider labels, and compact commands.
+- **Micro** (500, 10px, 1.2): secondary explanations and metadata.
+- **Mono** (600, 10px, 1.2): engine status, percentages, timers, and numerical readouts.
+
+**The Stable Number Rule.** Every changing percentage, timer, count, and comfort metric uses monospaced or monospaced-digit typography so controls do not shift.
+
+**The Native Voice Rule.** Buttons use sentence case and short verbs. Uppercase is reserved for terse engine metadata, never ordinary labels.
+
+## Elevation
+
+Deckle uses a hybrid of tonal layering and restrained ambient shadows. Surfaces are separated first by system background roles, then by a low-opacity hairline. Shadows indicate a surface that is physically above another surface, not decoration.
+
+### Shadow Vocabulary
+
+- **Control Lift:** `0 1px 2px rgba(0, 0, 0, 0.04)`. Circular toolbar controls and compact capsules.
+- **Texture Lift:** `0 1px 3px rgba(0, 0, 0, 0.08)`. Circular texture preview against the hero surface.
+- **Hero Lift:** `0 3px 8px rgba(0, 0, 0, 0.06)`. The primary status surface only.
+- **Paging Lift:** `0 2px 4px rgba(0, 0, 0, 0.12)`. Floating carousel navigation over paper cards.
+
+**The Ambient Only Rule.** Shadows remain diffuse and below 12% black. If an edge looks drawn or dirty, the shadow is too strong.
+
+**The One Raised Hero Rule.** The hero may be raised. Inner metric groups and control drawers use tonal separation, not another large shadow.
+
+## Components
+
+### Popover Shell
+
+- **Width:** fixed at 370 points.
+- **Padding:** 14 points around the content.
+- **Rhythm:** 12-point section spacing.
+- **Sizing:** fit current vertical content. Variable modes must not leave stale window material below the footer.
+- **Theme:** use `NSColor.windowBackgroundColor` and native appearance adaptation.
+
+### Top Actions
+
+- **Shape:** compact capsule for Open Mill; 36-point circles for notification and account actions.
+- **Icon badge:** 22-point colored circle inside the Open Mill capsule.
+- **State:** Open Mill changes to Close Mill while the editor exists. Notification color follows update status.
+- **Elevation:** Control Lift.
+
+### Search Field
+
+- **Shape:** gently rounded field (12-point radius), 40-point target height.
+- **Background:** control surface with an 8% semantic hairline.
+- **Focus:** accent-colored icon and 50% accent hairline.
+- **Behavior:** normalized whitespace; search immediately enters a focused results grid and removes the hero.
+
+### Hero Status Surface
+
+- **Shape:** 18-point radius with 16-point internal padding.
+- **Content order:** engine metadata, texture identity, status, primary action, then intensity.
+- **Preview:** 48-point circular live texture inside a 50-point holder.
+- **Primary action:** 38-point capsule. Neutral while active; accent-filled when enabling or resuming.
+- **Secondary action:** 38-point circular More control.
+- **Numbers:** monospaced percentages and timers.
+
+### Paper Cards
+
+- **Width:** 108 points. Three cards plus two 8-point gaps must fit the popover content width.
+- **Shape:** 12-point card radius and 8-point texture radius.
+- **Internal padding:** 8 points.
+- **Selection:** accent hairline and a subtle 9% accent wash. Do not rely on color alone; retain the checkmark.
+- **Text:** one-line paper name and one-line material tag.
+
+### Paper Library
+
+- **Compact mode:** horizontal carousel with a trailing fade and floating arrow only when at least three cards overflow.
+- **All Papers mode:** hide the hero and promo surfaces, show category chips, then a three-column vertical grid.
+- **Expanded viewport:** row-aware fixed height, capped at 236 points.
+- **Search viewport:** row-aware fixed height, capped at 360 points.
+- **Window fit:** the popover shell uses current content height so Compact removes expanded grid space immediately.
+- **Transition:** 200ms ease-out. No spring, bounce, or full-height slide.
+
+### Filter Chips
+
+- **Shape:** capsule, 4-point vertical and 10-point horizontal padding.
+- **Unselected:** quiet neutral fill with primary text.
+- **Selected:** current accent fill with contrasting text.
+- **Behavior:** switching back to Compact resets hidden category state to All.
+
+### Control Drawer
+
+- **Outer shape:** 16-point radius with 12-point padding.
+- **Inner control surface:** 14-point radius with 14-point padding.
+- **Tabs:** horizontally scrollable capsules with full labels. A trailing fade communicates overflow.
+- **Behavior:** remains reachable during search; opening All Papers closes it.
+
+### Notifications
+
+- **Shape:** 14-point tonal surface.
+- **Leading symbol:** 34 to 36-point rounded badge.
+- **State:** blue/accent for progress and availability, green for success, orange for failure, red only for the unread dot.
+- **Dismissal:** remember the dismissed version, not a global boolean.
+
+### Paper Mill
+
+- **Window:** resizable, minimum 400 by 500 points; position beside the MenuBarExtra within the owning display's visible frame.
+- **Preview:** 8-point rounded texture image with a subtle outline.
+- **Primary control:** Preview on Screen is prominent and becomes Stop Preview while active.
+- **Comfort readout:** compact two-column metric surface with monospaced numbers and a semantic grade chip.
+- **Performance:** render thumbnail at 1x during adjustment and 2x when settled; debounce real-overlay updates.
+
+## Do's and Don'ts
+
+### Do:
+
+- **Do** use the Apple system font and native semantic colors for application UI.
+- **Do** keep the popover at 370 points with 14-point outer padding and 12-point section rhythm.
+- **Do** give every vertical `ScrollView` inside MenuBarExtra a deterministic viewport height.
+- **Do** hide the hero when All Papers or search becomes the primary task.
+- **Do** use `.fixedSize(horizontal: false, vertical: true)` at the popover root when content height changes by mode.
+- **Do** keep card dimensions explicit: 108-point paper cards, 8-point gaps, three columns.
+- **Do** use 150 to 250ms state transitions with ease-out timing and no visible bounce.
+- **Do** use monospaced digits for live percentages, countdowns, counts, and comfort metrics.
+- **Do** use checkmarks, labels, or symbols alongside semantic color.
+- **Do** show carousel fades and arrows only when content actually overflows.
+- **Do** keep Paper Mill comfort language factual and non-medical.
+
+### Don't:
+
+- **Don't** use `.frame(maxHeight:)` alone for a flexible grid inside MenuBarExtra. It may collapse while the window keeps translucent empty space.
+- **Don't** stack the hero, control drawer, and expanded library in one vertical state.
+- **Don't** use decorative glassmorphism. Native window material is sufficient; content surfaces must remain readable and bounded.
+- **Don't** nest cards inside cards. Use spacing, dividers, and tonal groups before another container.
+- **Don't** use gradient text, neon accents, side-stripe borders, or oversized display typography.
+- **Don't** use success, warning, or danger colors outside their semantic meaning.
+- **Don't** hide a selected category when returning to Compact; reset it to All.
+- **Don't** truncate control-tab labels to make them fit. Keep the tab row scrollable and signal overflow.
+- **Don't** animate layout with spring bounce. Motion communicates a state change and then gets out of the way.
+- **Don't** leave blank material below the footer after a mode transition. If that occurs, the sizing contract is broken.


### PR DESCRIPTION
Adds the Deckle design system documentation: DESIGN.md (colors, typography, elevation, component specs, do's/don'ts) and its machine-readable DESIGN.json counterpart.

Why: the documented rules — fixed 370pt popover, 14pt outer padding, row-aware grid viewport capped at 236pt, "variable modes must not leave stale window material below the footer" — are the contract behind the expanded-library sizing fix (PR #30). The docs capture that contract so future UI changes stay honest to it.

Validation:
- `jq empty DESIGN.json` — valid JSON.
- `git diff --check` — clean.
- Docs-only change; no code or test files touched, so no test run is included.