### PR TITLE
Release Deckle 1.7.4

### DIFF
--- a/Support/Info.plist
+++ b/Support/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.3</string>
+	<string>1.7.4</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>16</string>
+	<string>17</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary

- explain why an in-place update cannot run instead of silently opening GitHub
- preserve the pinned GitHub download invariant in private updater state
- prevent background and automatic checks from opening the browser
- dismiss blocked-update messaging in one click
- direct non-admin users to `~/Applications` or manual installation
- add deterministic updater transition and security tests
- bump the app to 1.7.4 (build 17)

## Verification

- `plutil -lint Support/Info.plist`
- `swift test` (30 tests passed)
- `make build UNIVERSAL=1` (arm64 + x86_64)
- bundled 1.7.2 read-only fixture: failure banner rendered at 370x636, one-click dismissal returned to 370x540 without a replacement banner or blank footer material
