### PR TITLE
fix: dynamically resize MenuBarExtra popover to fit content

### DIFF
--- a/Sources/Deckle/MenuPopover.swift
+++ b/Sources/Deckle/MenuPopover.swift
@@ -1,0 +1,174 @@
+import AppKit
+import SwiftUI
+
+/// Fits the menu to its content, keeping the native MenuBarExtra window in sync.
+/// MenuBarExtra does not reliably shrink its window when SwiftUI content size decreases,
+/// which can leave a blank frosted-glass region at the bottom.
+/// MenuPopover actively synchronizes the native window frame with the content's measured height
+/// and guarantees an opaque background across the entire popover.
+@MainActor
+struct MenuPopover<Content: View>: View {
+    let preferredWidth: CGFloat
+    @ViewBuilder let content: () -> Content
+    @State private var measuredHeight: CGFloat = 0
+    @State private var availableMaxHeight: CGFloat = .infinity
+
+    var body: some View {
+        let isConstrained = measuredHeight > availableMaxHeight && availableMaxHeight > 0
+        let effectiveHeight = measuredHeight > 0 ? min(measuredHeight, availableMaxHeight) : nil
+
+        ZStack(alignment: .top) {
+            Color(nsColor: .windowBackgroundColor).opacity(0.96)
+                .ignoresSafeArea()
+
+            if isConstrained {
+                ScrollView(.vertical) {
+                    content()
+                        .frame(width: preferredWidth)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .background(sizingView)
+                }
+                .frame(width: preferredWidth, height: effectiveHeight, alignment: .top)
+            } else {
+                content()
+                    .frame(width: preferredWidth)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .background(sizingView)
+                    .frame(width: preferredWidth, height: effectiveHeight, alignment: .top)
+            }
+        }
+        .frame(width: preferredWidth, height: effectiveHeight, alignment: .top)
+    }
+
+    private var sizingView: some View {
+        MenuSizingRepresentable { height, maxH in
+            if abs(measuredHeight - height) >= 0.5 {
+                measuredHeight = height
+            }
+            if abs(availableMaxHeight - maxH) >= 0.5 {
+                availableMaxHeight = maxH
+            }
+        }
+    }
+}
+
+/// Geometry uses AppKit's bottom-left screen coordinates, including displays
+/// left of or below the primary screen. Shrinking preserves the menu's top.
+enum MenuPopoverGeometry {
+    static func frame(size: CGSize, anchoredTo current: CGRect, visibleFrame: CGRect) -> CGRect {
+        let top = min(current.maxY, visibleFrame.maxY)
+        let width = min(size.width, visibleFrame.width)
+        let height = min(size.height, max(0, top - visibleFrame.minY))
+        return CGRect(
+            x: min(max(current.minX, visibleFrame.minX), visibleFrame.maxX - width),
+            y: top - height,
+            width: width,
+            height: height
+        )
+    }
+}
+
+@MainActor
+private struct MenuSizingRepresentable: NSViewRepresentable {
+    let onSizeChanged: @MainActor (CGFloat, CGFloat) -> Void
+
+    func makeNSView(context: Context) -> MenuSizingView {
+        let view = MenuSizingView()
+        view.onSizeChanged = onSizeChanged
+        return view
+    }
+
+    func updateNSView(_ nsView: MenuSizingView, context: Context) {
+        nsView.onSizeChanged = onSizeChanged
+        nsView.scheduleSizing()
+    }
+
+    static func dismantleNSView(_ nsView: MenuSizingView, coordinator: ()) {
+        nsView.stopObserving()
+        nsView.onSizeChanged = nil
+    }
+}
+
+@MainActor
+final class MenuSizingView: NSView {
+    var onSizeChanged: (@MainActor (CGFloat, CGFloat) -> Void)?
+    private var sizingScheduled = false
+    private var lastMeasuredHeight: CGFloat = 0
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        stopObserving()
+        guard let window else { return }
+        let center = NotificationCenter.default
+        for name in [
+            NSWindow.didMoveNotification,
+            NSWindow.didChangeScreenNotification,
+            NSWindow.didChangeOcclusionStateNotification
+        ] {
+            center.addObserver(self, selector: #selector(windowGeometryChanged), name: name, object: window)
+        }
+        center.addObserver(
+            self,
+            selector: #selector(windowGeometryChanged),
+            name: NSApplication.didChangeScreenParametersNotification,
+            object: nil
+        )
+        scheduleSizing()
+    }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        guard newSize.height > 50, newSize.width > 0 else { return }
+        if abs(newSize.height - lastMeasuredHeight) >= 0.5 {
+            lastMeasuredHeight = newSize.height
+            scheduleSizing()
+        }
+    }
+
+    func stopObserving() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func windowGeometryChanged(_ notification: Notification) {
+        scheduleSizing()
+    }
+
+    func scheduleSizing() {
+        guard !sizingScheduled else { return }
+        sizingScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.sizingScheduled = false
+            self.synchronizeWindow()
+        }
+    }
+
+    private func synchronizeWindow() {
+        guard let window, window.isVisible, let screen = window.screen,
+              lastMeasuredHeight > 50 else { return }
+
+        let visible = screen.visibleFrame
+        let top = min(window.frame.maxY, visible.maxY)
+        let maxHeight = max(100, top - visible.minY)
+        let targetHeight = min(lastMeasuredHeight, maxHeight)
+
+        onSizeChanged?(lastMeasuredHeight, maxHeight)
+
+        let targetWidth = bounds.width > 0 ? bounds.width : window.frame.width
+        let target = MenuPopoverGeometry.frame(
+            size: CGSize(width: targetWidth, height: targetHeight),
+            anchoredTo: window.frame,
+            visibleFrame: visible
+        )
+
+        let tolerance = 1 / window.backingScaleFactor
+        guard abs(target.width - window.frame.width) >= tolerance
+            || abs(target.height - window.frame.height) >= tolerance
+            || abs(target.minX - window.frame.minX) >= tolerance
+            || abs(target.minY - window.frame.minY) >= tolerance else { return }
+
+        window.setFrame(target, display: true, animate: false)
+    }
+}

--- a/Sources/Deckle/MenuView.swift
+++ b/Sources/Deckle/MenuView.swift
@@ -16,6 +16,12 @@ struct MenuView: View {
     @FocusState private var isSearchFocused: Bool
 
     var body: some View {
+        MenuPopover(preferredWidth: 370) {
+            content
+        }
+    }
+
+    private var content: some View {
         VStack(spacing: 12) {
             // 1. Top Navigation & Action Header (Always Pinned at Top)
             topHeaderBar
@@ -76,8 +82,6 @@ struct MenuView: View {
         }
         .padding(14)
         .frame(width: 370)
-        .fixedSize(horizontal: false, vertical: true)
-        .background(Color(nsColor: .windowBackgroundColor).opacity(0.96))
         .animation(.spring(response: 0.32, dampingFraction: 0.82), value: isDetailsExpanded)
         .animation(.spring(response: 0.3, dampingFraction: 0.8), value: dismissedUpdateVersion)
         // MenuBarExtra sizes its native window from the content's fitting size.

--- a/Sources/Deckle/PresetCardView.swift
+++ b/Sources/Deckle/PresetCardView.swift
@@ -151,7 +151,7 @@ struct PresetCollectionView: View {
         let contentHeight = CGFloat(rowCount) * cardHeight
             + CGFloat(max(0, rowCount - 1)) * rowSpacing
             + 4
-        return min(isSearching ? 360 : 236, max(cardHeight + 4, contentHeight))
+        return min(isSearching ? 360 : 356, max(cardHeight + 4, contentHeight))
     }
 
     private var filteredPresets: [TexturePreset] {

--- a/Tests/DeckleTests/MenuPopoverTests.swift
+++ b/Tests/DeckleTests/MenuPopoverTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+import SwiftUI
+@testable import Deckle
+
+final class MenuPopoverTests: XCTestCase {
+    func testShrinkingContentPreservesTopEdgeOnNegativeCoordinateDisplay() {
+        let current = CGRect(x: -1800, y: -700, width: 370, height: 540)
+        let visible = CGRect(x: -1920, y: -1080, width: 1920, height: 1055)
+        let resized = MenuPopoverGeometry.frame(
+            size: CGSize(width: 370, height: 210), anchoredTo: current, visibleFrame: visible
+        )
+
+        XCTAssertEqual(resized.size, CGSize(width: 370, height: 210))
+        XCTAssertEqual(resized.maxY, current.maxY)
+        XCTAssertEqual(resized.minX, current.minX)
+    }
+
+    func testOversizedContentIsBoundedByAvailableScreenBelowAnchor() {
+        let current = CGRect(x: -1000, y: -500, width: 370, height: 450)
+        let visible = CGRect(x: -1920, y: -1080, width: 1920, height: 1055)
+        let resized = MenuPopoverGeometry.frame(
+            size: CGSize(width: 2300, height: 2000), anchoredTo: current, visibleFrame: visible
+        )
+
+        XCTAssertTrue(visible.contains(resized))
+        XCTAssertEqual(resized.width, visible.width)
+        XCTAssertEqual(resized.minY, visible.minY)
+        XCTAssertEqual(resized.maxY, current.maxY)
+    }
+
+    @MainActor
+    func testMenuViewFittingSize() {
+        let host = NSHostingView(rootView: MenuView().environmentObject(AppState.shared))
+        XCTAssertGreaterThan(host.fittingSize.height, 400)
+        XCTAssertEqual(host.fittingSize.width, 370)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the issue where switching to All Papers or filtering to smaller categories leaves a blank frosted-glass region at the bottom of the popover (as captured in `IMG_3441.HEIC`).

### Root Cause
- `MenuBarExtra(.window)` creates a native `NSPopover` / `MenuBarExtraWindow` sized initially to the full menu (~623 pt with hero card + feature promo card).
- When switching to All Papers or filtering by category/search, SwiftUI hides `HeroCardView` and `FeaturePromoCard`.
- macOS `MenuBarExtraWindow` does not automatically shrink downwards when content becomes shorter.
- Because `.background(Color(...))` was attached directly to the shrinking content `VStack`, the bottom ~180 pt of the window remained bare translucent visual effect material.
- In addition, `PresetCollectionView` was clamping the All Papers grid to `236` pt (2 rows), forcing cards into an unnecessarily small scroll viewport.

### Changes
1. **MenuPopover & MenuSizingView**:
   - Implemented `MenuPopover` with an underlying `NSViewRepresentable` (`MenuSizingView`) that tracks content size changes directly via AppKit `setFrameSize(_:)`.
   - Actively synchronizes the native `NSWindow` frame to the content's measured height anchored to the top edge (`maxY`), cleanly shrinking and expanding the popover window across any display coordinate system.
   - Enforces opaque `windowBackgroundColor` across the entire `ZStack` root container so frosted glass is never exposed.
   - Enables outer vertical scrolling only when content exceeds available screen space below the menu bar, avoiding nested scrollview conflicts with the preset `LazyVGrid`.
2. **Library Viewport Balancing**:
   - Expanded `gridViewportHeight` bound to `356` pt (3 full rows of cards) so browsing All Papers displays 9 papers comfortably (~600 pt total popover height matching compact mode), while single-row categories (e.g. "Dark") and search results shrink the window snugly.

### Verification
- `swift test`: all 33 tests passed (including `MenuPopoverTests` layout and anchoring tests).
- `make build UNIVERSAL=1`: clean release build for both `arm64` and `x86_64`.
- `make app`: tested live `dist/Deckle.app` across compact, All Papers (3 rows), single-row categories ("Dark"), Tune Paper expansion (787 pt), and collapses with zero residual gap or layout jump.